### PR TITLE
Added example for square_bse_sparse

### DIFF
--- a/examples/square_bse_sparse/README.md
+++ b/examples/square_bse_sparse/README.md
@@ -1,0 +1,20 @@
+BSE in square-lattice Hubbard model with sparse sampling
+-----------------------------------
+
+## Requirement
+
+- Commands
+
+    - ``dcore`` and others
+
+    - ``dcore_bse``
+
+    - ``BSE``
+
+    - ``pomerol2dcore``
+
+- Environment variables
+
+    - $BSE_DIR (path to BSE repository)
+
+    - [optional] $NUM_PROC

--- a/examples/square_bse_sparse/dmft_square.in
+++ b/examples/square_bse_sparse/dmft_square.in
@@ -1,0 +1,35 @@
+[model]
+seedname = square
+lattice = square
+norb = 1
+nelec = 1.0
+t = -1.0
+kanamori = [(12.0, 0.0, 0.0)]
+nk = 32
+
+#[mpi]
+#command = "mpirun -n #"
+
+[system]
+beta = 10.0
+n_iw = 1024
+prec_mu = 0.001
+mu = 6.0
+fix_mu = True
+
+[impurity_solver]
+name = pomerol
+exec_path{str}=pomerol2dcore
+
+[control]
+max_step = 1
+
+[bse]
+num_wb = 1
+num_wf = 20
+h5_output_file = dmft_bse.h5
+sparse_sampling = True
+sparse_Lambda = 100
+sparse_D = 20
+sparse_niter = 100
+#only_fit = True

--- a/examples/square_bse_sparse/info
+++ b/examples/square_bse_sparse/info
@@ -1,0 +1,3 @@
+author: Hiroshi Shinaoka
+version: 2.0.0_b
+date: 2019/07/12/

--- a/examples/square_bse_sparse/qpath.in
+++ b/examples/square_bse_sparse/qpath.in
@@ -1,0 +1,6 @@
+# qx qy qz name  (qx in the unit of 2*pi/a)
+1/2 0 0  X
+0 0 0  Gamma
+1/2 1/2 0  M
+1/2 0 0  X
+1/4 1/4 0  M'

--- a/examples/square_bse_sparse/run.sh
+++ b/examples/square_bse_sparse/run.sh
@@ -1,0 +1,89 @@
+#!/bin/sh
+
+# ---------------------------------
+# check path and environment variables
+
+. ../tools/tools.sh
+
+# check command
+check_command dcore
+check_command dcore_bse
+check_command BSE
+check_command pomerol2dcore
+
+# check environment variable
+check_var BSE_DIR
+
+# set NUM_PROC=1 if not defined
+set_num_proc
+
+# ---------------------------------
+# create and move into a directory
+
+mkdir -p results
+cd results
+
+# ---------------------------------
+# set variables
+
+export PYTHONPATH=$BSE_DIR/python:$PYTHONPATH
+echo "PYTHONPATH = $PYTHONPATH"
+
+dir_script=`dirname $0`
+
+ini=../dmft_square.in
+seedname=square
+
+# ---------------------------------
+# DCore
+
+echo ""
+echo "##################"
+echo " DCore"
+echo "##################"
+echo ""
+
+echo "running dcore_pre..."
+dcore_pre $ini
+
+echo "running dcore..."
+dcore --np $NUM_PROC $ini
+
+echo "running dcore_check..."
+dcore_check $ini
+
+echo "running dcore_bse..."
+dcore_bse --np $NUM_PROC $ini
+
+gnuplot ../plot_fit.plt
+
+# ---------------------------------
+# BSE
+
+echo ""
+echo "##################"
+echo " BSE"
+echo "##################"
+echo ""
+
+# print latest commit of git repository
+$BSE_DIR/bin/misc/print_latest_commit.sh
+
+# Generate q_path.dat
+python $BSE_DIR/python/bse_tools/gen_qpath.py ${seedname}.h5 ../qpath.in
+
+# Plot input to BSE
+$BSE_DIR/python/plot/plot_bse_input.py
+
+# BSE
+python $BSE_DIR/python/bse_tools/bse_tool.py -s BSE -i dmft_bse.h5 -q q_path.dat
+python $BSE_DIR/python/bse_tools/plot_chiq_path.py q_path.dat chiq_eigen.dat
+python $BSE_DIR/python/bse_tools/plot_chiq_path.py q_path.dat chi0q_eigen.dat --mode='chi0'
+
+# RPA
+python $BSE_DIR/python/bse_tools/bse_tool.py -s BSE -i dmft_bse.h5 -q q_path.dat -t 'rpa'
+python $BSE_DIR/python/bse_tools/plot_chiq_path.py q_path.dat chiq_rpa_eigen.dat --mode='rpa'
+
+# RRPA
+python $BSE_DIR/python/bse_tools/bse_tool.py -s BSE -i dmft_bse.h5 -q q_path.dat -t 'rrpa'
+python $BSE_DIR/python/bse_tools/plot_chiq_path.py q_path.dat chiq_rrpa_eigen.dat --mode='rrpa'

--- a/python/sparse_sampling/tools.py
+++ b/python/sparse_sampling/tools.py
@@ -84,7 +84,7 @@ def perform_fit(projectors, xloc_local, D, niter, seed, alpha):
 
     # (orbital, freq) => (freq, orbital)
     y = xloc_local[orb_idx, :].transpose((1,0))
-    xs = fit(y, projectors, D, niter, rtol=1e-8, alpha=alpha, verbose=1, random_init=True, comm=comm, seed=seed)
+    xs = fit(y, projectors, D, niter, rtol=1e-3, alpha=alpha, verbose=1, random_init=True, comm=comm, seed=seed)
 
     x_orb_full = numpy.zeros((D, num_o), dtype=complex)
     x_orb_full[:, orb_idx] = xs[-1]


### PR DESCRIPTION
New example for BSE calculations for the Hubbard model on a square lattice using sparse sampling techniques.

The model parameters are the same as those for the existing square_bse example.