### PR TITLE
Custom mpirun for test autodoc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ FROM shinaoka/triqs1.4_dmft_alps
 COPY ./ $HOME/src/DCore
 
 RUN pip install sphinx wild-sphinx-theme
+# Workaround for a bug in docutils 0.15
+RUN pip install -U docutils==0.14
 
 WORKDIR $HOME/src/DCore
 RUN mkdir $HOME/build/DCore

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -135,11 +135,17 @@ Installation steps
 
      $ make
 
-#. We recommend that you run the tests to check if the compiling is properly finished. Type
+#. We recommend to run the tests to check if DCore is built correctly. Type
 
    ::
 
      $ make test
+
+   If your system MPI wrapper is not "mpirun", please provide the name of the correct one to DCore through cmake by using the flag "-DMPIRUN_COMMAND".
+   The default value is "mpirun -np #" (# is replaced by the number of processors).
+   For instance, if your wrapper is "mpijob" and you do not need to specify the number of processors explicitly, please use -DMPIRUN_COMMAND=mpijob.
+   Note that it is not allowed to run MPI programs interactively on some system.
+   In this case, please run tests as a job.
 
    The test results look like
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -19,6 +19,11 @@ if (TRIQS_VERSION STREQUAL "1.4")
     add_subdirectory(chain_hubbardI)
 endif()
 
+if (NOT MPIRUN_COMMAND)
+    set(MPIRUN_COMMAND "mpirun -np \#")
+endif()
+message(STATUS "Using ${MPIRUN_COMMAND} for running some tests")
+
 option(TEST_DEV "Activate developers' test" OFF)
 if(TEST_DEV)
     message(STATUS "Activated developers' test")

--- a/test/chain_hubbardI/CMakeLists.txt
+++ b/test/chain_hubbardI/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(TEST_FILES dmft.ini)
 foreach(test_file ${TEST_FILES})
-    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${test_file} ${CMAKE_CURRENT_BINARY_DIR} COPYONLY)
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${test_file}.in ${CMAKE_CURRENT_BINARY_DIR}/${test_file})
 endforeach()
 
 # COPY REFERENCE DATA

--- a/test/chain_hubbardI/dmft.ini.in
+++ b/test/chain_hubbardI/dmft.ini.in
@@ -6,8 +6,10 @@ t = 1.0
 norb = 3
 interaction = kanamori
 kanamori = [(8.0, 5.3333333, 1.33333)]
-spin_orbit = True
 nk = 20
+
+[mpi]
+command = @MPIRUN_COMMAND@
 
 [system]
 beta = 5.0

--- a/test/chain_hubbardI_so/CMakeLists.txt
+++ b/test/chain_hubbardI_so/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(TEST_FILES dmft.ini)
 foreach(test_file ${TEST_FILES})
-    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${test_file} ${CMAKE_CURRENT_BINARY_DIR} COPYONLY)
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${test_file}.in ${CMAKE_CURRENT_BINARY_DIR}/${test_file})
 endforeach()
 
 # COPY REFERENCE DATA

--- a/test/chain_hubbardI_so/dmft.ini.in
+++ b/test/chain_hubbardI_so/dmft.ini.in
@@ -6,7 +6,11 @@ t = 1.0
 norb = 3
 interaction = kanamori
 kanamori = [(8.0, 5.3333333, 1.33333)]
+spin_orbit = True
 nk = 20
+
+[mpi]
+command = @MPIRUN_COMMAND@
 
 [system]
 beta = 5.0


### PR DESCRIPTION
This fixes failure of mpi-dependent unit tests on sekirei.
One can specify the name of a MPI wrapper to DCore via cmake.
The documentation has been updated accordingly.