### PR TITLE
Pass chi_loc to BSE solver

### DIFF
--- a/python/dcore_bse.py
+++ b/python/dcore_bse.py
@@ -74,7 +74,7 @@ def calc_g2_in_impurity_model(solver_name, solver_params, mpirun_command, basis_
     if flag_box:
         xloc, chiloc = sol.calc_Xloc_ph(rot, mpirun_command, num_wf, num_wb, s_params)
     else:
-        xloc, chiloc = sol.calc_Xloc_ph_sparse(rot, mpirun_command, freqs, s_params)
+        xloc, chiloc = sol.calc_Xloc_ph_sparse(rot, mpirun_command, freqs, num_wb, s_params)
 
     # Check results for x_loc
     print("\n checking x_loc...")

--- a/python/dcore_bse.py
+++ b/python/dcore_bse.py
@@ -72,11 +72,11 @@ def calc_g2_in_impurity_model(solver_name, solver_params, mpirun_command, basis_
 
     # Solve the model
     if flag_box:
-        xloc = sol.calc_Xloc_ph(rot, mpirun_command, num_wf, num_wb, s_params)
+        xloc, chiloc = sol.calc_Xloc_ph(rot, mpirun_command, num_wf, num_wb, s_params)
     else:
-        xloc = sol.calc_Xloc_ph_sparse(rot, mpirun_command, freqs, s_params)
+        xloc, chiloc = sol.calc_Xloc_ph_sparse(rot, mpirun_command, freqs, s_params)
 
-    # Check results
+    # Check results for x_loc
     print("\n checking x_loc...")
     assert isinstance(xloc, dict)
     for key, data in xloc.items():
@@ -87,9 +87,18 @@ def calc_g2_in_impurity_model(solver_name, solver_params, mpirun_command, basis_
             assert data.shape == (freqs.shape[0],)
     print(" OK")
 
+    # Check results for chi_loc
+    if chiloc is not None:
+        print("\n checking chi_loc...")
+        assert isinstance(chiloc, dict)
+        for key, data in chiloc.items():
+            print("  ", key)
+            assert data.shape == (num_wb, )
+        print(" OK")
+
     os.chdir(work_dir_org)
 
-    return xloc, sol.get_Gimp_iw()
+    return xloc, chiloc, sol.get_Gimp_iw()
 
 
 def subtract_disconnected(xloc, gimp, spin_names, freqs=None):
@@ -268,7 +277,7 @@ class SaveBSE:
         else:
             raise ValueError("bse_info =", bse_info)
 
-    def save_xloc(self, xloc_ijkl, icrsh):
+    def _save_common(self, xloc_ijkl, icrsh, key_type):
 
         h5bse = h5BSE(self.h5_file, self.bse_grp)
 
@@ -306,10 +315,16 @@ class SaveBSE:
 
                 if (s12, s34) not in xloc_bse:
                     xloc_bse[(s12, s34)] = numpy.zeros((n_inner2, n_inner2) + data_wb.shape, dtype=complex)
-                xloc_bse[(s12, s34)][inner12, inner34, :, :] = data_wb[:, :]
+                xloc_bse[(s12, s34)][inner12, inner34] = data_wb  # copy
 
             # save
-            h5bse.save(key=('X_loc', wb), data=xloc_bse)
+            h5bse.save(key=(key_type, wb), data=xloc_bse)
+
+    def save_xloc(self, xloc_ijkl, icrsh):
+        self._save_common(xloc_ijkl, icrsh, 'X_loc')
+
+    def save_chiloc(self, chiloc_ijkl, icrsh):
+        self._save_common(chiloc_ijkl, icrsh, 'chi_loc')
 
     def save_gamma0(self, u_mat, icrsh):
 
@@ -478,22 +493,27 @@ class DMFTBSESolver(DMFTCoreSolver):
         for ish in range(self._n_inequiv_shells):
             print("\nSolving impurity model for inequivalent shell " + str(ish) + " ...")
             sys.stdout.flush()
-            x_loc, g_imp = calc_g2_in_impurity_model(solver_name, self._solver_params, self._mpirun_command,
-                                                     self._params["impurity_solver"]["basis_rotation"],
-                                                     self._Umat[ish], self._gf_struct[ish], self._beta, self._n_iw,
-                                                     self._sh_quant[ish].Sigma_iw, Gloc_iw_sh[ish],
-                                                     self._params['bse']['num_wb'],
-                                                     self._params['bse']['num_wf'], ish, freqs=freqs)
+            x_loc, chi_loc, g_imp = calc_g2_in_impurity_model(solver_name, self._solver_params, self._mpirun_command,
+                                                              self._params["impurity_solver"]["basis_rotation"],
+                                                              self._Umat[ish], self._gf_struct[ish],
+                                                              self._beta, self._n_iw,
+                                                              self._sh_quant[ish].Sigma_iw, Gloc_iw_sh[ish],
+                                                              self._params['bse']['num_wb'],
+                                                              self._params['bse']['num_wf'], ish, freqs=freqs)
 
             subtract_disconnected(x_loc, g_imp, self.spin_block_names, freqs=freqs)
 
-            # save X_loc
+            # save X_loc, chi_loc
             for icrsh in range(self._n_corr_shells):
                 if ish == self._sk.corr_to_inequiv[icrsh]:
+                    # X_loc
                     if flag_sparse:
                         bse.save_xloc_sparse(x_loc, icrsh=icrsh)
                     else:
                         bse.save_xloc(x_loc, icrsh=icrsh)
+                    # chi_loc
+                    if chi_loc is not None:
+                        bse.save_chiloc(chi_loc, icrsh=icrsh)
 
     def calc_bse(self):
         """

--- a/python/impurity_solvers/alps_cthyb.py
+++ b/python/impurity_solvers/alps_cthyb.py
@@ -130,7 +130,7 @@ class ALPSCTHYBSolver(SolverBase):
     def calc_Xloc_ph_sparse(self, rot, mpirun_command, freqs_ph, params_kw):
         self._solve_impl(rot, mpirun_command, freqs_ph, params_kw)
 
-        return self._Xloc_ph_sparse
+        return self._Xloc_ph_sparse, None
 
     def _solve_impl(self, rot, mpirun_command, freqs_ph, params_kw):
         """

--- a/python/impurity_solvers/alps_cthyb.py
+++ b/python/impurity_solvers/alps_cthyb.py
@@ -127,7 +127,7 @@ class ALPSCTHYBSolver(SolverBase):
     def calc_Xloc_ph(self, rot, mpirun_command, num_wf, num_wb, params_kw):
         raise RuntimeError("calc_Xloc_ph is not implemented!")
 
-    def calc_Xloc_ph_sparse(self, rot, mpirun_command, freqs_ph, params_kw):
+    def calc_Xloc_ph_sparse(self, rot, mpirun_command, freqs_ph, num_wb, params_kw):
         self._solve_impl(rot, mpirun_command, freqs_ph, params_kw)
 
         return self._Xloc_ph_sparse, None

--- a/python/impurity_solvers/base.py
+++ b/python/impurity_solvers/base.py
@@ -147,14 +147,15 @@ class SolverBase(object):
 
     def calc_Xloc_ph(self, rot, mpirun_command, num_wf, num_wb, params_kw):
         """
-        Compute Xloc(n, n', m) in p-h channel
+        Compute Xloc(m, n, n') in p-h channel
+                and chi_loc(m) (optional)
 
 
         Parameters
         ----------
         num_wf:
             Number of non-negative fermionic frequencies
-        num_wb
+        num_wb:
             Number of non-negative bosonic frequencies
 
         The other parameters are the same as for solve().
@@ -162,15 +163,19 @@ class SolverBase(object):
         Returns
         -------
 
-        Xloc(n, n', m) : 3d ndarray of complex type
+        Xloc(m, n, n') : 3d ndarray of complex type
             Data for -num_wf <= n, n' < num_wf and m = 0, 1, ..., num_wb-1.
+
+        chi_loc(m) : 1d ndarray of complex type
+            return None if not computed
 
         """
         pass
 
-    def calc_Xloc_ph_sparse(self, rot, mpirun_command, freqs_ph, params_kw):
+    def calc_Xloc_ph_sparse(self, rot, mpirun_command, freqs_ph, num_wb, params_kw):
         """
-        Compute Xloc(n, n', m) in p-h channel only for specified frequency points
+        Compute Xloc(m, n, n') in p-h channel only for specified frequency points
+                and chi_loc(m) (optional)
 
         Parameters
         ----------
@@ -183,11 +188,16 @@ class SolverBase(object):
             in the particle-hole convention.
             These frequencies must be given in the order of (boson, fermion, fermion).
 
+        num_wb:
+            for chi_loc
+
         params_kw:
             The same as solve()
 
         Returns
         -------
+        Xloc
+        chi_loc
 
         """
         pass

--- a/python/impurity_solvers/pomerol.py
+++ b/python/impurity_solvers/pomerol.py
@@ -29,7 +29,7 @@ from pytriqs.operators import *
 from ..tools import make_block_gf, launch_mpi_subprocesses, extract_H0
 from .base import SolverBase
 
-VERSION_REQUIRED = 1.0
+VERSION_REQUIRED = 1.1
 
 
 def check_version(_exec):
@@ -127,9 +127,13 @@ class PomerolSolver(SolverBase):
 
         # for BSE
         flag_vx = params_kw.get('flag_vx', 0)
-        n_w2f = params_kw.get('num_wf', None)
-        n_w2b = params_kw.get('num_wb', None)
+        n_w2f = params_kw.get('n_w2f', None)
+        n_w2b = params_kw.get('n_w2b', None)
         file_freqs = params_kw.get('file_freqs', None)
+
+        # dynamical susceptibility
+        flag_suscep = params_kw.get('flag_suscep', 0)
+        n_wb = params_kw.get('n_wb', None)
 
         file_pomerol = "pomerol.in"
         file_h0 = "h0.in"
@@ -143,11 +147,13 @@ class PomerolSolver(SolverBase):
             'file_h0': file_h0,
             'file_umat': file_umat,
             'flag_gf': 1,
-            'n_w': self.n_iw,
+            'n_wf': self.n_iw,
             'flag_vx': flag_vx,
             'n_w2f': n_w2f,
             'n_w2b': n_w2b,
-            'file_freqs': file_freqs
+            'file_freqs': file_freqs,
+            'flag_suscep': flag_suscep,
+            'n_wb': n_wb,
         }
 
         with open(file_pomerol, "w") as f:
@@ -209,12 +215,10 @@ class PomerolSolver(SolverBase):
         g0_inv -= h0_block
         self._Sigma_iw << g0_inv - inverse(self._Gimp_iw)
 
-    def read_xloc(self, params_kw):
-        dir_g2 = params_kw.get('dir_g2', './two_particle')
-
+    def _read_common(self, dir_name, fac=1.0):
         x_loc = {}
         for i1, i2, i3, i4 in product(range(self.n_flavors), repeat=4):
-            filename = dir_g2 + "/%d_%d_%d_%d.dat" % (i1, i2, i3, i4)
+            filename = dir_name + "/%d_%d_%d_%d.dat" % (i1, i2, i3, i4)
             if not os.path.exists(filename):
                 continue
             print(" reading", filename)
@@ -222,9 +226,17 @@ class PomerolSolver(SolverBase):
             # load data as a complex type
             data = numpy.loadtxt(filename).view(complex).reshape(-1)
 
-            x_loc[(i1, i2, i3, i4)] = data / self.beta
+            x_loc[(i1, i2, i3, i4)] = data * fac
 
         return x_loc
+
+    def _read_xloc(self, params_kw):
+        dir_g2 = params_kw.get('dir_g2', './two_particle')
+        return self._read_common(dir_g2, 1./self.beta)
+
+    def _read_chiloc(self, params_kw):
+        dir_suscep = params_kw.get('dir_suscep', './susceptibility')
+        return self._read_common(dir_suscep)
 
     def calc_Xloc_ph(self, rot, mpirun_command, num_wf, num_wb, params_kw):
         """
@@ -245,19 +257,27 @@ class PomerolSolver(SolverBase):
             key = (i1, i2, i3, i4)
             val = numpy.ndarray(n_w2b, 2*n_w2f, 2*n_w2f)
 
+        chi_loc : dict (None if not computed)
+            key = (i1, i2, i3, i4)
+            val = numpy.ndarray(n_w2b)
         """
 
         params_kw['flag_vx'] = 1
-        params_kw['num_wf'] = num_wf
-        params_kw['num_wb'] = num_wb
+        params_kw['n_w2f'] = num_wf
+        params_kw['n_w2b'] = num_wb
+        params_kw['flag_suscep'] = 1
+        params_kw['n_wb'] = num_wb
 
         self.solve(rot, mpirun_command, params_kw)
 
-        x_loc = self.read_xloc(params_kw)
+        x_loc = self._read_xloc(params_kw)
         # 1d array --> (wb, wf1, wf2)
         for key, data in x_loc.items():
             x_loc[key] = data.reshape((num_wb, 2*num_wf, 2*num_wf))
-        return x_loc
+
+        chi_loc = self._read_chiloc(params_kw)
+
+        return x_loc, chi_loc
 
     def calc_Xloc_ph_sparse(self, rot, mpirun_command, freqs_ph, params_kw):
         """
@@ -282,10 +302,11 @@ class PomerolSolver(SolverBase):
 
         params_kw['flag_vx'] = 1
         params_kw['file_freqs'] = file_freqs
+        params_kw['flag_suscep'] = 1
 
         self.solve(rot, mpirun_command, params_kw)
 
-        x_loc = self.read_xloc(params_kw)
+        x_loc = self._read_xloc(params_kw)
         return x_loc
 
     def name(self):

--- a/python/impurity_solvers/pomerol.py
+++ b/python/impurity_solvers/pomerol.py
@@ -29,7 +29,7 @@ from pytriqs.operators import *
 from ..tools import make_block_gf, launch_mpi_subprocesses, extract_H0
 from .base import SolverBase
 
-VERSION_REQUIRED = 1.1
+VERSION_REQUIRED = 1.2
 
 
 def check_version(_exec):

--- a/python/impurity_solvers/pomerol.py
+++ b/python/impurity_solvers/pomerol.py
@@ -279,12 +279,13 @@ class PomerolSolver(SolverBase):
 
         return x_loc, chi_loc
 
-    def calc_Xloc_ph_sparse(self, rot, mpirun_command, freqs_ph, params_kw):
+    def calc_Xloc_ph_sparse(self, rot, mpirun_command, freqs_ph, num_wb, params_kw):
         """
 
         Parameters
         ----------
         freqs_ph : numpy.ndarray[N, 3]  frequency points (in the order of boson, fermion, fermion)
+        num_wb : for chi_loc
 
         Returns
         -------
@@ -306,6 +307,7 @@ class PomerolSolver(SolverBase):
         params_kw['flag_vx'] = 1
         params_kw['file_freqs'] = file_freqs
         params_kw['flag_suscep'] = 1
+        params_kw['n_wb'] = num_wb
 
         self.solve(rot, mpirun_command, params_kw)
 

--- a/python/impurity_solvers/pomerol.py
+++ b/python/impurity_solvers/pomerol.py
@@ -292,6 +292,9 @@ class PomerolSolver(SolverBase):
             key = (i1, i2, i3, i4)
             val = numpy.ndarray(N)
 
+        chi_loc : dict (None if not computed)
+            key = (i1, i2, i3, i4)
+            val = numpy.ndarray(n_w2b)
         """
 
         # Save frequencies list
@@ -307,7 +310,8 @@ class PomerolSolver(SolverBase):
         self.solve(rot, mpirun_command, params_kw)
 
         x_loc = self._read_xloc(params_kw)
-        return x_loc
+        chi_loc = self._read_chiloc(params_kw)
+        return x_loc, chi_loc
 
     def name(self):
         return "pomerol"


### PR DESCRIPTION
``dcore_bse`` saves not only X_loc but also chi_loc, if available.

At present, only pomerol solver supports chi_loc. ``pomerol`` and ``pomerol2dcore`` needs to be updated.