### PR TITLE
Option for replacing default value of `mpi.command`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 
 option(BUILD_DCORE "Build DCore" ON)
 
-option(MPIEXEC "default of mpi.command" OFF)
+option(MPIEXEC "Default value of mpi.command" OFF)
 if(NOT MPIEXEC)
   set(MPIEXEC "mpirun -np \#")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,11 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 
 option(BUILD_DCORE "Build DCore" ON)
 
+option(MPIEXEC "default of mpi.command" OFF)
+if(NOT MPIEXEC)
+  set(MPIEXEC "mpirun -np \#")
+endif()
+
 # start configuration 
 cmake_minimum_required(VERSION 2.8)
 project(DCore NONE)

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -26,7 +26,7 @@ file(GLOB_RECURSE all_doc_files RELATIVE ${CMAKE_SOURCE_DIR}/doc * EXCLUDE *.swp
 add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/doc_source.tar DEPENDS ${all_doc_files} COMMAND ${CMAKE_COMMAND} -E tar cf ${CMAKE_BINARY_DIR}/doc_source.tar ${all_doc_files} WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/doc)
 add_custom_target(make_doc_local_copy_dir ALL COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/doc_source)
 add_custom_target(copy_tar_doc ALL DEPENDS ${CMAKE_BINARY_DIR}/doc_source.tar make_doc_local_copy_dir COMMAND ${CMAKE_COMMAND} -E tar xf ${CMAKE_BINARY_DIR}/doc_source.tar WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/doc_source)
-add_custom_target(make_option_tables ALL DEPENDS copy_tar_doc COMMAND ${PYTHON_INTERPRETER} ${CMAKE_SOURCE_DIR}/python/option_tables.py ${CMAKE_BINARY_DIR}/doc_source/reference)
+add_custom_target(make_option_tables ALL DEPENDS copy_tar_doc COMMAND ${PYTHON_INTERPRETER} ${CMAKE_BINARY_DIR}/python/dcore/option_tables.py ${CMAKE_BINARY_DIR}/doc_source/reference)
 add_custom_target(make_doc_local_copy ALL DEPENDS make_option_tables)
 
 # create documentation target

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -86,6 +86,11 @@ Installation steps
    Please set CMAKE_INSTALL_PREFIX to the directory where DCore will be installed.
    If the cmake command succeeded, you will see the following message.
 
+   DCore invokes some MPI parallelized impurity solver in a DMFT loop.
+   If your system MPI command is not "mpirun", please provide the name of the correct one to DCore through cmake by using the flag "-DMPIEXEC".
+   The default value is "mpirun -np #" (# is replaced by the number of processors).
+   For instance, if your wrapper is "mpijob" and you do not need to specify the number of processors explicitly, please use ``-DMPIEXEC="mpijob"``.
+
    ::
 
      -- Build files have been written to: /.../dcore.build
@@ -102,9 +107,7 @@ Installation steps
 
      $ make test
 
-   If your system MPI wrapper is not "mpirun", please provide the name of the correct one to DCore through cmake by using the flag "-DMPIEXEC".
-   The default value is "mpirun -np #" (# is replaced by the number of processors).
-   For instance, if your wrapper is "mpijob" and you do not need to specify the number of processors explicitly, please use -DMPIEXEC=mpijob.
+   Some of tests invoke an MPI parallelized impourity solver.
    Note that it is not allowed to run MPI programs interactively on some system.
    In this case, please run tests as a job.
 

--- a/doc/reference/input.rst
+++ b/doc/reference/input.rst
@@ -313,4 +313,5 @@ This block includes parameters which are read by ``dcore`` and ``dcore_post``.
 
 .. include:: mpi_desc.txt
 
-The default value of ``command`` can be replaced with ``<MPIRUN>`` by passing ``-DMPIEXEC=<MPIRUN>`` option to the ``cmake`` command.
+When an option ``-DMPIEXEC=<MPIRUN>`` is passed to the ``cmake`` command,
+The default value of ``command`` will be replaced with ``<MPIRUN>``.

--- a/doc/reference/input.rst
+++ b/doc/reference/input.rst
@@ -312,3 +312,5 @@ This block includes parameters that are solely used by ``dcore_post``.
 This block includes parameters which are read by ``dcore`` and ``dcore_post``.
 
 .. include:: mpi_desc.txt
+
+The default value of ``command`` can be replaced with ``<MPIRUN>`` by passing ``-DMPIEXEC=<MPIRUN>`` option to the ``cmake`` command.

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -7,7 +7,7 @@ configure_file(${CMAKE_SOURCE_DIR}/cmake/sitecustomize.py ${CMAKE_CURRENT_BINARY
 
 # Install path
 install(DIRECTORY ${CMAKE_SOURCE_DIR}/python/ DESTINATION
-${CMAKE_INSTALL_PREFIX}/lib/python2.7/site-packages/dcore FILES_MATCHING PATTERN *.py)
+    ${DCORE_SITE_PACKAGES}/dcore FILES_MATCHING PATTERN *.py)
 
 # Copy all Python files for ctest into a build directory
 file(GLOB_RECURSE all_py_files RELATIVE ${CMAKE_SOURCE_DIR}/python *.py)
@@ -20,6 +20,9 @@ add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/py_source.tar
 )
 
 add_custom_target(copy_tar_py ALL DEPENDS ${CMAKE_BINARY_DIR}/py_source.tar)
+
+configure_file(mpi_command.py.in ${CMAKE_CURRENT_BINARY_DIR}/dcore/mpi_command.py @ONLY)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/dcore/mpi_command.py DESTINATION ${DCORE_SITE_PACKAGES}/dcore)
 
 # add version file
 configure_file(version.py.in version.py)

--- a/python/mpi_command.py.in
+++ b/python/mpi_command.py.in
@@ -1,0 +1,1 @@
+default_mpi_command = "@MPIEXEC@"

--- a/python/program_options.py
+++ b/python/program_options.py
@@ -24,6 +24,8 @@ import re
 import ast
 from collections import namedtuple
 
+from mpi_command import default_mpi_command
+
 
 def create_parser(target_sections=None):
     """
@@ -35,7 +37,7 @@ def create_parser(target_sections=None):
         parser = TypedParser(target_sections)
 
     # [mpi]
-    parser.add_option("mpi", "command", str, "mpirun -np #", "Command for executing a MPI job. # will be relaced by the number of processes.")
+    parser.add_option("mpi", "command", str, default_mpi_command, "Command for executing a MPI job. # will be relaced by the number of processes.")
 
     # [model]
     parser.add_option("model", "seedname", str, "dcore", "Name of the system. The model HDF5 file will be seedname.h5.")

--- a/test/bse_sparse/CMakeLists.txt
+++ b/test/bse_sparse/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(CONFIG_FILES sparse_fit.ini.ref sparse_fit.ini.Lambda100)
 foreach(config_file ${CONFIG_FILES})
-    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${config_file}.in ${CMAKE_CURRENT_BINARY_DIR}/${config_file} @ONLY)
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${config_file} ${CMAKE_CURRENT_BINARY_DIR}/${config_file} COPYONLY)
 endforeach()
 
 add_python_test(bse_sparse)

--- a/test/bse_sparse/sparse_fit.ini.Lambda100
+++ b/test/bse_sparse/sparse_fit.ini.Lambda100
@@ -7,9 +7,6 @@ t = -1.0
 kanamori = [(8.0, 0.0, 0.0)]
 nk = 1
 
-[mpi]
-command = @MPIEXEC@
-
 [system]
 beta = 10.0
 n_iw = 1024

--- a/test/bse_sparse/sparse_fit.ini.ref
+++ b/test/bse_sparse/sparse_fit.ini.ref
@@ -7,9 +7,6 @@ t = -1.0
 kanamori = [(8.0, 0.0, 0.0)]
 nk = 1
 
-[mpi]
-command = @MPIEXEC@
-
 [system]
 beta = 10.0
 n_iw = 1024

--- a/test/chain_hubbardI/CMakeLists.txt
+++ b/test/chain_hubbardI/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(TEST_FILES dmft.ini)
 foreach(test_file ${TEST_FILES})
-    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${test_file}.in ${CMAKE_CURRENT_BINARY_DIR}/${test_file})
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${test_file} ${CMAKE_CURRENT_BINARY_DIR}/${test_file} COPYONLY)
 endforeach()
 
 # COPY REFERENCE DATA

--- a/test/chain_hubbardI/dmft.ini
+++ b/test/chain_hubbardI/dmft.ini
@@ -8,9 +8,6 @@ interaction = kanamori
 kanamori = [(8.0, 5.3333333, 1.33333)]
 nk = 20
 
-[mpi]
-command = @MPIEXEC@
-
 [system]
 beta = 5.0
 with_dc = True

--- a/test/chain_hubbardI_so/CMakeLists.txt
+++ b/test/chain_hubbardI_so/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(TEST_FILES dmft.ini)
 foreach(test_file ${TEST_FILES})
-    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${test_file}.in ${CMAKE_CURRENT_BINARY_DIR}/${test_file})
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${test_file} ${CMAKE_CURRENT_BINARY_DIR}/${test_file} COPYONLY)
 endforeach()
 
 # COPY REFERENCE DATA

--- a/test/chain_hubbardI_so/dmft.ini
+++ b/test/chain_hubbardI_so/dmft.ini
@@ -9,9 +9,6 @@ kanamori = [(8.0, 5.3333333, 1.33333)]
 spin_orbit = True
 nk = 20
 
-[mpi]
-command = @MPIEXEC@
-
 [system]
 beta = 5.0
 with_dc = True


### PR DESCRIPTION
`cmake -DMPIEXEC=<MPIRUN>` replaces the default value of `mpi.command` with `<MPIRUN>`