### PR TITLE
no_tail_fit option

### DIFF
--- a/src/dcore/dmft_core.py
+++ b/src/dcore/dmft_core.py
@@ -60,16 +60,16 @@ warnings.filterwarnings("ignore", message="numpy.ufunc size changed")
 #             total_density += g_iw_.total_density().real
 #     return total_density
 
-def _total_density(bgf, fitting=True):
+def _total_density(bgf, tail_fit=True):
     assert isinstance(bgf, BlockGf)
-    if fitting:
+    if tail_fit:
         return bgf.total_density().real
     else:
         return calc_total_density(bgf).real
 
-def _density(bgf, fitting=True):
+def _density(bgf, tail_fit=True):
     assert isinstance(bgf, BlockGf)
-    if fitting:
+    if tail_fit:
         return bgf.density()
     else:
         return calc_density_matrix(bgf)
@@ -761,8 +761,8 @@ class DMFTCoreSolver(object):
             self._params['control']['symmetry_generators'],
             self._use_spin_orbit, self._dim_sh)
 
-        # No fitting in computing density if no_tail_fit=True
-        fitting = not self._params['system']['no_tail_fit']
+        # No tail fit in computing density if no_tail_fit=True
+        tail_fit = not self._params['system']['no_tail_fit']
 
         def quantities_to_check():
             x = []
@@ -814,7 +814,7 @@ class DMFTCoreSolver(object):
             self._quant_to_save_history['spin_moment'] = smoment_sh
 
             # Compute Total charge from G_loc
-            charge_loc = [_total_density(Gloc_iw_sh[ish], fitting) for ish in range(self._n_inequiv_shells)]
+            charge_loc = [_total_density(Gloc_iw_sh[ish], tail_fit) for ish in range(self._n_inequiv_shells)]
             for ish, charge in enumerate(charge_loc):
                 print("\n  Total charge of Gloc_{shell %d} : %.6f" % (ish, charge))
             self._quant_to_save_history['total_charge_loc'] = charge_loc
@@ -832,7 +832,7 @@ class DMFTCoreSolver(object):
             #
 
             # Compute Total charge from G_imp
-            charge_imp = [_total_density(new_Gimp_iw[ish], fitting) for ish in range(self._n_inequiv_shells)]
+            charge_imp = [_total_density(new_Gimp_iw[ish], tail_fit) for ish in range(self._n_inequiv_shells)]
             for ish, charge in enumerate(charge_imp):
                 print("\n  Total charge of Gimp_{shell %d} : %.6f" % (ish, charge))
             self._quant_to_save_history['total_charge_imp'] = charge_imp
@@ -861,7 +861,7 @@ class DMFTCoreSolver(object):
 
             # update DC correction
             if with_dc and dc_type == "HF_imp":
-                dm_imp = [_density(new_Gimp_iw[ish], fitting) for ish in range(self._n_inequiv_shells)]
+                dm_imp = [_density(new_Gimp_iw[ish], tail_fit) for ish in range(self._n_inequiv_shells)]
                 self.set_dc_imp(dm_imp)
 
             self._quant_to_save_history.update(chemical_potential=self._chemical_potential,

--- a/src/dcore/dmft_core.py
+++ b/src/dcore/dmft_core.py
@@ -544,7 +544,7 @@ class DMFTCoreSolver(object):
             'dc_energ'      : self._dc_energ,
             'mu'            : self._chemical_potential,
             'adjust_mu'     : False,
-            'matsubara_sum_without_fitting' : self._params['system']['matsubara_sum_without_fitting'],
+            'no_tail_fit'   : self._params['system']['no_tail_fit'],
         }
 
     def calc_G0loc(self):
@@ -761,8 +761,8 @@ class DMFTCoreSolver(object):
             self._params['control']['symmetry_generators'],
             self._use_spin_orbit, self._dim_sh)
 
-        # No fitting in computing density if matsubara_sum_without_fitting=True
-        fitting = not self._params['system']['matsubara_sum_without_fitting']
+        # No fitting in computing density if no_tail_fit=True
+        fitting = not self._params['system']['no_tail_fit']
 
         def quantities_to_check():
             x = []

--- a/src/dcore/dmft_core.py
+++ b/src/dcore/dmft_core.py
@@ -529,6 +529,7 @@ class DMFTCoreSolver(object):
             'dc_energ'      : self._dc_energ,
             'mu'            : self._chemical_potential,
             'adjust_mu'     : False,
+            'matsubara_sum_without_fitting' : self._params['system']['matsubara_sum_without_fitting'],
         }
 
     def calc_G0loc(self):

--- a/src/dcore/fourier.py
+++ b/src/dcore/fourier.py
@@ -1,3 +1,21 @@
+#
+# DCore -- Integrated DMFT software for correlated electrons
+# Copyright (C) 2017 The University of Tokyo
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
 import numpy
 from scipy import fft
 from itertools import product

--- a/src/dcore/fourier.py
+++ b/src/dcore/fourier.py
@@ -1,0 +1,104 @@
+import numpy
+from scipy import fft
+
+
+
+def _matsubara_freq_fermion(beta, nw):
+    iw_positive = numpy.array([(2*i+1) * numpy.pi / beta for i in range(nw)])
+    iw = numpy.append(-iw_positive[::-1], iw_positive) * 1j
+    return iw
+
+
+def _fft_fermion_w2t(gw, beta, a=1):
+    # nw_2 = gw.size
+    assert gw.size % 2 == 0  # even
+    nw = gw.size // 2
+    nt = 2 * nw
+    # print("nt =", nt)
+    # print("nw =", nw)
+
+    iw = _matsubara_freq_fermion(beta, nw)
+    assert iw.shape == (2*nw,)
+
+    # Subtract 1/iw
+    gw_subtract = gw - a / iw
+
+    # Change order to positive-w, negative-w
+    gw_subtract = numpy.roll(gw_subtract, nw)
+
+    # fermion to full
+    gw_full = numpy.zeros(4*nw, dtype=numpy.complex128)
+    gw_full[1::2] = gw_subtract[:]
+
+    # FFT
+    gt_full = fft.fft(gw_full) / beta
+    # print(gt_full.shape)
+    assert gt_full.shape == (2*nt,)
+    assert numpy.all(numpy.abs(gt_full.imag) < 1e-8)  # real
+    gt_full = gt_full.real
+
+    # Extract [0:beta], Add -1/2
+    gt_fermion = numpy.zeros(nt+1, dtype=numpy.float64)
+    gt_fermion[0:nt] = gt_full[0:nt] - a / 2
+    gt_fermion[-1] = - a - gt_fermion[0]
+
+    assert gt_fermion.shape == (nt+1,)
+    return gt_fermion
+
+
+def _fft_fermion_t2w(gt, beta):
+    assert gt.size % 2 == 1  # odd
+    a =  - gt[0] - gt[-1]
+    # print("a=", a)
+    nt = gt.size - 1
+    nw = nt // 2
+    # print("nt =", nt)
+    # print("nw =", nw)
+
+    iw = _matsubara_freq_fermion(beta, nw)
+    assert iw.shape == (2*nw,)
+
+    # Subtract -1/2
+    gt_subtract = gt[:-1] + a / 2
+    # print(gt_subtract.shape)
+
+    # beta to 2*beta
+    gt_full = numpy.append(gt_subtract, -gt_subtract)
+    # print(gt_full.shape)
+    # print(gt_full)
+
+    # FFT
+    # gw_full = fft.fft(gt_full, norm='backward') * beta
+    gw_full = fft.ifft(gt_full) * beta
+    # gw_full = fft.ifft(gt_full) * (beta / nt)
+    # print("gw_full.shape =", gw_full.shape)
+    assert gw_full.shape == (4*nw,)
+
+    # Extract fermion
+    gw_fermion = gw_full[1::2]
+    assert gw_fermion.shape == (2*nw,)
+
+    # Change order to negative-w, positive-w
+    gw_fermion = numpy.roll(gw_fermion, nw)
+
+    # Add 1/iw
+    gw_fermion += a / iw
+
+    return gw_fermion
+
+
+
+def fermion_fourier(gf, iw, beta, coef_inv_iw=1, direction='w2t'):
+    isinstance(gf, numpy.ndarray)
+    isinstance(iw, numpy.ndarray)
+    assert gf.ndim == 1
+    assert iw.ndim == 1
+    assert gf.size == iw.size
+
+    n = gf.size
+
+
+def bgf_fourier(bgf, direction='w2t'):
+    isinstance(bgf, BlockGf)
+
+    iw = numpy.array([g.mesh(n) for n in range(g.mesh.first_index(), g.mesh.last_index()+1)])

--- a/src/dcore/program_options.py
+++ b/src/dcore/program_options.py
@@ -92,7 +92,7 @@ def create_parser(target_sections=None):
                       "Threshold for calculating chemical potential with the bisection method.")
     parser.add_option("system", "with_dc", bool, False, "Whether or not use double-counting correction (See below)")
     parser.add_option("system", "dc_type", str, 'HF_DFT', "Chosen from 'HF_DFT' (default), 'HF_imp', 'FLL'")
-    parser.add_option("system", "matsubara_sum_without_fitting", bool, False, "Compute Matsubara summation without fitting high-frequency moments.")
+    parser.add_option("system", "no_tail_fit", bool, False, "Compute Matsubara summation without fitting high-frequency moments.")
 
     # [impurity_solver]
     parser.add_option("impurity_solver", "name", str, 'null',

--- a/src/dcore/program_options.py
+++ b/src/dcore/program_options.py
@@ -92,6 +92,7 @@ def create_parser(target_sections=None):
                       "Threshold for calculating chemical potential with the bisection method.")
     parser.add_option("system", "with_dc", bool, False, "Whether or not use double-counting correction (See below)")
     parser.add_option("system", "dc_type", str, 'HF_DFT', "Chosen from 'HF_DFT' (default), 'HF_imp', 'FLL'")
+    parser.add_option("system", "matsubara_sum_without_fitting", bool, False, "Compute Matsubara summation without fitting high-frequency moments.")
 
     # [impurity_solver]
     parser.add_option("impurity_solver", "name", str, 'null',

--- a/src/dcore/sumkdft_opt.py
+++ b/src/dcore/sumkdft_opt.py
@@ -2,6 +2,7 @@ import numpy
 import copy
 from warnings import warn
 from dcore._dispatcher import *
+from .tools import calc_total_density, calc_density_matrix
 
 class SumkDFT_opt(SumkDFT):
 
@@ -462,3 +463,158 @@ class SumkDFT_opt(SumkDFT):
             return None
         else:
             return gf_upfolded
+
+    ###############################################################
+    # OVERRIDE FUNCTIONS
+    # The density is computed by simple Matsubara summation
+    # to avoid "High frequency error"
+    # Replaced parts are indicated by "+++REPLACED"
+    ###############################################################
+
+
+    def total_density_matsubara(self, mu=None, iw_or_w="iw", with_Sigma=True, with_dc=True, broadening=None):
+        r"""
+        Calculates the total charge within the energy window for a given chemical potential.
+        The chemical potential is either given by parameter `mu` or, if it is not specified,
+        taken from `self.chemical_potential`.
+        The total charge is calculated from the trace of the GF in the Bloch basis.
+        By default, a full interacting GF is used. To use the non-interacting GF, set
+        parameter `with_Sigma = False`.
+        The number of bands within the energy windows generally depends on `k`. The trace is
+        therefore calculated separately for each `k`-point.
+        Since in general n_orbitals depends on k, the calculation is done in the following order:
+        .. math:: n_{tot} = \sum_{k} n(k),
+        with
+        .. math:: n(k) = Tr G_{\nu\nu'}(k, i\omega_{n}).
+        The calculation is done in the global coordinate system, if distinction is made between local/global.
+        Parameters
+        ----------
+        mu : float, optional
+             Input chemical potential. If not specified, `self.chemical_potential` is used instead.
+        iw_or_w : string, optional
+                  - `iw_or_w` = 'iw' for a imaginary-frequency self-energy
+                  - `iw_or_w` = 'w' for a real-frequency self-energy
+        with_Sigma : boolean, optional
+             If `True` the full interacing GF is evaluated, otherwise the self-energy is not
+             included and the charge would correspond to a non-interacting system.
+        with_dc : boolean, optional
+             Whether or not to subtract the double-counting term from the self-energy.
+        broadening : float, optional
+                     Imaginary shift for the axis along which the real-axis GF is calculated.
+                     If not provided, broadening will be set to double of the distance between mesh points in 'mesh'.
+                     Only relevant for real-frequency GF.
+        Returns
+        -------
+        dens : float
+               Total charge :math:`n_{tot}`.
+        """
+
+        if mu is None:
+            mu = self.chemical_potential
+        dens = 0.0
+        ikarray = numpy.array(list(range(self.n_k)))
+        for ik in mpi.slice_array(ikarray):
+            G_latt = self.lattice_gf(
+                ik=ik, mu=mu, iw_or_w=iw_or_w, with_Sigma=with_Sigma, with_dc=with_dc, broadening=broadening)
+            # dens += self.bz_weights[ik] * G_latt.total_density()
+            # +++REPLACED
+            dens += self.bz_weights[ik] * calc_total_density(G_latt)
+        # collect data from mpi:
+        dens = mpi.all_reduce(mpi.world, dens, lambda x, y: x + y)
+        mpi.barrier()
+
+        if abs(dens.imag) > 1e-20:
+            mpi.report("Warning: Imaginary part in density will be ignored ({})".format(str(abs(dens.imag))))
+        return dens.real
+
+
+    def density_matrix_matsubara(self, method='using_gf', beta=40.0):
+        """Calculate density matrices in one of two ways.
+        Parameters
+        ----------
+        method : string, optional
+                 - if 'using_gf': First get lattice gf (g_loc is not set up), then density matrix.
+                                  It is useful for Hubbard I, and very quick.
+                                  No assumption on the hopping structure is made (ie diagonal or not).
+                 - if 'using_point_integration': Only works for diagonal hopping matrix (true in wien2k).
+        beta : float, optional
+               Inverse temperature.
+        Returns
+        -------
+        dens_mat : list of dicts
+                   Density matrix for each spin in each correlated shell.
+        """
+        dens_mat = [{} for icrsh in range(self.n_corr_shells)]
+        for icrsh in range(self.n_corr_shells):
+            for sp in self.spin_block_names[self.corr_shells[icrsh]['SO']]:
+                dens_mat[icrsh][sp] = numpy.zeros(
+                    [self.corr_shells[icrsh]['dim'], self.corr_shells[icrsh]['dim']], numpy.complex_)
+
+        ikarray = numpy.array(list(range(self.n_k)))
+        for ik in mpi.slice_array(ikarray):
+
+            if method == "using_gf":
+
+                G_latt_iw = self.lattice_gf(
+                    ik=ik, mu=self.chemical_potential, iw_or_w="iw", beta=beta)
+                # G_latt_iw *= self.bz_weights[ik]
+                # dm = G_latt_iw.density()
+                # MMat = [dm[sp] for sp in self.spin_block_names[self.SO]]
+                # +++REPLACED
+                dm = calc_density_matrix(G_latt_iw)
+                MMat = [dm[sp] * self.bz_weights[ik] for sp in self.spin_block_names[self.SO]]
+
+            elif method == "using_point_integration":
+
+                ntoi = self.spin_names_to_ind[self.SO]
+                spn = self.spin_block_names[self.SO]
+                dims = {sp:self.n_orbitals[ik, ntoi[sp]] for sp in spn}
+                MMat = [numpy.zeros([dims[sp], dims[sp]], numpy.complex_) for sp in spn]
+
+                for isp, sp in enumerate(spn):
+                    ind = ntoi[sp]
+                    for inu in range(self.n_orbitals[ik, ind]):
+                        # only works for diagonal hopping matrix (true in
+                        # wien2k)
+                        if (self.hopping[ik, ind, inu, inu] - self.h_field * (1 - 2 * isp)) < 0.0:
+                            MMat[isp][inu, inu] = 1.0
+                        else:
+                            MMat[isp][inu, inu] = 0.0
+
+            else:
+                raise ValueError("density_matrix: the method '%s' is not supported." % method)
+
+            for icrsh in range(self.n_corr_shells):
+                for isp, sp in enumerate(self.spin_block_names[self.corr_shells[icrsh]['SO']]):
+                    ind = self.spin_names_to_ind[
+                        self.corr_shells[icrsh]['SO']][sp]
+                    dim = self.corr_shells[icrsh]['dim']
+                    n_orb = self.n_orbitals[ik, ind]
+                    projmat = self.proj_mat[ik, ind, icrsh, 0:dim, 0:n_orb]
+                    if method == "using_gf":
+                        dens_mat[icrsh][sp] += numpy.dot(numpy.dot(projmat, MMat[isp]),
+                                                         projmat.transpose().conjugate())
+                    elif method == "using_point_integration":
+                        dens_mat[icrsh][sp] += self.bz_weights[ik] * numpy.dot(numpy.dot(projmat, MMat[isp]),
+                                                                               projmat.transpose().conjugate())
+
+        # get data from nodes:
+        for icrsh in range(self.n_corr_shells):
+            for sp in dens_mat[icrsh]:
+                dens_mat[icrsh][sp] = mpi.all_reduce(
+                    mpi.world, dens_mat[icrsh][sp], lambda x, y: x + y)
+        mpi.barrier()
+
+        if self.symm_op != 0:
+            dens_mat = self.symmcorr.symmetrize(dens_mat)
+
+        # Rotate to local coordinate system:
+        if self.use_rotations:
+            for icrsh in range(self.n_corr_shells):
+                for sp in dens_mat[icrsh]:
+                    if self.rot_mat_time_inv[icrsh] == 1:
+                        dens_mat[icrsh][sp] = dens_mat[icrsh][sp].conjugate()
+                    dens_mat[icrsh][sp] = numpy.dot(numpy.dot(self.rot_mat[icrsh].conjugate().transpose(), dens_mat[icrsh][sp]),
+                                                    self.rot_mat[icrsh])
+
+        return dens_mat

--- a/src/dcore/sumkdft_workers/gloc_worker.py
+++ b/src/dcore/sumkdft_workers/gloc_worker.py
@@ -14,6 +14,12 @@ class SumkDFTWorkerGloc(SumkDFTWorkerBase):
 
         sk = SumkDFT(hdf_file=self.model_hdf5_file, use_dft_blocks=False, h_field=0.0)
         setup_sk(sk, 'iwn', self.params)
+
+        # workaround for 'High frequency error'
+        if True:
+            sk.total_density = sk.total_density_matsubara
+            sk.density_matrix = sk.density_matrix_matsubara
+
         if self.params['adjust_mu']:
             # find the chemical potential for given density
             sk.calc_mu(self.params['prec_mu'])

--- a/src/dcore/sumkdft_workers/gloc_worker.py
+++ b/src/dcore/sumkdft_workers/gloc_worker.py
@@ -16,7 +16,7 @@ class SumkDFTWorkerGloc(SumkDFTWorkerBase):
         setup_sk(sk, 'iwn', self.params)
 
         # workaround for 'High frequency error'
-        if True:
+        if self.params['matsubara_sum_without_fitting']:
             sk.total_density = sk.total_density_matsubara
             sk.density_matrix = sk.density_matrix_matsubara
 

--- a/src/dcore/sumkdft_workers/gloc_worker.py
+++ b/src/dcore/sumkdft_workers/gloc_worker.py
@@ -16,7 +16,7 @@ class SumkDFTWorkerGloc(SumkDFTWorkerBase):
         setup_sk(sk, 'iwn', self.params)
 
         # workaround for 'High frequency error'
-        if self.params['matsubara_sum_without_fitting']:
+        if self.params['no_tail_fit']:
             sk.total_density = sk.total_density_matsubara
             sk.density_matrix = sk.density_matrix_matsubara
 

--- a/src/dcore/tools.py
+++ b/src/dcore/tools.py
@@ -912,3 +912,92 @@ def expand_path(exec_path):
         sys.exit(1)
 
     return full_path
+
+
+def _calc_density(gf):
+    """Calculte density by Matsubara summation
+
+    Parameters
+    ----------
+    gf : GfImFreq
+
+    Returns
+    -------
+    total_density: float
+
+    """
+    assert isinstance(gf, GfImFreq)
+
+    beta = gf.mesh.beta
+
+    # sum over iw and trace over orb of g.data[iw, orb1, orb2]
+    density = numpy.sum(numpy.trace(gf.data, axis1=1, axis2=2)) / beta
+
+    # contribution of 1/iw
+    density += 0.5 * gf.data.shape[1]
+
+    # equivalent to
+    # iw = numpy.array([g.mesh(n) for n in range(g.mesh.first_index(), g.mesh.last_index()+1)])
+    # assert iw.shape[0] == g.data.shape[0]
+    # density += (0.5 - numpy.sum(1 / iw) / beta) * g.data.shape[1]
+
+    return density
+
+
+def calc_total_density(block_gf):
+    """Calculte total density by Matsubara summation
+
+    Parameters
+    ----------
+    block_gf : BlockGf
+
+    Returns
+    -------
+    total_density: float
+
+    """
+    assert isinstance(block_gf, BlockGf)
+
+    return numpy.sum([_calc_density(g) for _, g in block_gf])
+
+
+def _calc_density_matrix(gf):
+    """Calculte density matrix by Matsubara summation
+
+    Parameters
+    ----------
+    gf : GfImFreq
+
+    Returns
+    -------
+    density_matrix: numpy.ndarray
+
+    """
+    assert isinstance(gf, GfImFreq)
+
+    beta = gf.mesh.beta
+
+    # sum over iw of g.data[iw, orb1, orb2]
+    dm = numpy.sum(gf.data, axis=0) / beta
+
+    # contribution of 1/iw
+    dm += numpy.identity(gf.data.shape[1]) * 0.5
+
+    return dm
+
+
+def calc_density_matrix(block_gf):
+    """Calculte density matrix by Matsubara summation
+
+    Parameters
+    ----------
+    block_gf : BlockGf
+
+    Returns
+    -------
+    density_matrix: dict(numpy.ndarray)
+
+    """
+    assert isinstance(block_gf, BlockGf)
+
+    return {bname: _calc_density_matrix(g) for bname, g in block_gf}

--- a/src/dcore/tools.py
+++ b/src/dcore/tools.py
@@ -926,7 +926,7 @@ def _calc_density(gf):
     total_density: float
 
     """
-    assert isinstance(gf, GfImFreq)
+    assert isinstance(gf, Gf)
 
     beta = gf.mesh.beta
 
@@ -973,7 +973,7 @@ def _calc_density_matrix(gf):
     density_matrix: numpy.ndarray
 
     """
-    assert isinstance(gf, GfImFreq)
+    assert isinstance(gf, Gf)
 
     beta = gf.mesh.beta
 

--- a/tests/non-mpi/fourier/fourier.py
+++ b/tests/non-mpi/fourier/fourier.py
@@ -16,33 +16,42 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-from dcore.fourier import _fft_fermion_w2t, _fft_fermion_t2w, _matsubara_freq_fermion
+from dcore.fourier import _fft_fermion_w2t, _fft_fermion_t2w, _matsubara_freq_fermion, bgf_fourier_w2t
+from dcore.tools import make_block_gf
+from dcore._dispatcher import BlockGf, Gf, GfImFreq, GfImTime
 import numpy
 import os
+from itertools import product
 
 
-def test_ftt_fermion(request):
-    org_dir = os.getcwd()
-    os.chdir(request.fspath.dirname)
-
+def _make_g0():
     beta = 10.0
     # nw = 2048
     nw = 1024
     # nw = 512
     nt = 2 * nw
     e0 = 2.0
+    a = 0.1
 
-    print("nw =", nw)
-    print("nt =", nt)
+    # print("nw =", nw)
+    # print("nt =", nt)
 
     iw = _matsubara_freq_fermion(beta, nw)
-    g0_w = 1 / (iw - e0)
+    g0_w = a / (iw - e0)
 
     t = numpy.linspace(0, beta, nt+1)
-    g0_t = -numpy.exp(-t*e0) / (numpy.exp(-beta*e0) + 1)
-    a = - g0_t[0] - g0_t[-1]
+    g0_t = -numpy.exp(-t*e0) / (numpy.exp(-beta*e0) + 1) * a
+    # a = - g0_t[0] - g0_t[-1]
 
-    # test for t2w
+    return g0_w, g0_t, beta, a
+
+
+# test for t2w
+def test_fft_fermion_t2w(request):
+    org_dir = os.getcwd()
+    os.chdir(request.fspath.dirname)
+
+    g0_w, g0_t, beta, a = _make_g0()
 
     g0_w_fft = _fft_fermion_t2w(g0_t, beta)
 
@@ -50,9 +59,15 @@ def test_ftt_fermion(request):
     # numpy.savetxt('g0_w_fft.dat', g0_w_fft.view(float).reshape(-1,2))
     # numpy.savetxt('g0_w_diff.dat', (g0_w_fft - g0_w).view(float).reshape(-1,2))
 
-    assert numpy.allclose(g0_w_fft, g0_w, atol=1e-3)
+    assert numpy.allclose(g0_w_fft, g0_w, atol=1e-4)
 
-    # test for w2t
+
+# test for w2t
+def test_fft_fermion_w2t(request):
+    org_dir = os.getcwd()
+    os.chdir(request.fspath.dirname)
+
+    g0_w, g0_t, beta, a = _make_g0()
 
     g0_t_fft = _fft_fermion_w2t(g0_w, beta, a=a)
 
@@ -60,4 +75,46 @@ def test_ftt_fermion(request):
     # numpy.savetxt('g0_t_fft.dat', g0_t_fft)
     # numpy.savetxt('g0_t_diff.dat', g0_t_fft - g0_t)
 
-    assert numpy.allclose(g0_t_fft, g0_t, atol=1e-3)
+    assert numpy.allclose(g0_t_fft, g0_t, atol=1e-4)
+
+
+# test for w2t
+def test_fft_bgf_w2t(request):
+    org_dir = os.getcwd()
+    os.chdir(request.fspath.dirname)
+
+    g0_w, g0_t, beta, a = _make_g0()
+
+    nt = g0_t.size
+    nw = g0_w.size // 2
+
+    # print("nt =", nt)
+    # print("nw =", nw)
+
+    gf_struct = {'up': [0, 1]}
+
+    bgf_w = make_block_gf(GfImFreq, gf_struct, beta, nw)
+    # bgf_t = make_block_gf(GfImTime, gf_struct, beta, nt)
+
+    for name, gf in bgf_w:
+        nw_2, norb1, norb2 = gf.data.shape
+        assert nw_2 == nw*2
+        for i, j in product(range(norb1), range(norb2)):
+            if i == j:
+                gf.data[:, i, j] = g0_w[:]
+            else:
+                gf.data[:, i, j] = numpy.zeros(2*nw)
+
+    tail = {'up': numpy.identity(2) * a}
+
+    bgf_t = bgf_fourier_w2t(bgf_w, tail=tail)
+
+    for name, gf in bgf_t:
+        nt_2, norb1, norb2 = gf.data.shape
+        assert nt_2 == nt
+        for i, j in product(range(norb1), range(norb2)):
+            if i == j:
+                assert numpy.allclose(gf.data[:, i, j], g0_t, atol=1e-4)
+            else:
+                assert numpy.allclose(gf.data[:, i, j], numpy.zeros(nt))
+

--- a/tests/non-mpi/fourier/fourier.py
+++ b/tests/non-mpi/fourier/fourier.py
@@ -1,0 +1,63 @@
+#
+# DCore -- Integrated DMFT software for correlated electrons
+# Copyright (C) 2017 The University of Tokyo
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+from dcore.fourier import _fft_fermion_w2t, _fft_fermion_t2w, _matsubara_freq_fermion
+import numpy
+import os
+
+
+def test_ftt_fermion(request):
+    org_dir = os.getcwd()
+    os.chdir(request.fspath.dirname)
+
+    beta = 10.0
+    # nw = 2048
+    nw = 1024
+    # nw = 512
+    nt = 2 * nw
+    e0 = 2.0
+
+    print("nw =", nw)
+    print("nt =", nt)
+
+    iw = _matsubara_freq_fermion(beta, nw)
+    g0_w = 1 / (iw - e0)
+
+    t = numpy.linspace(0, beta, nt+1)
+    g0_t = -numpy.exp(-t*e0) / (numpy.exp(-beta*e0) + 1)
+    a = - g0_t[0] - g0_t[-1]
+
+    # test for t2w
+
+    g0_w_fft = _fft_fermion_t2w(g0_t, beta)
+
+    # numpy.savetxt('g0_w.dat', g0_w.view(float).reshape(-1,2))
+    # numpy.savetxt('g0_w_fft.dat', g0_w_fft.view(float).reshape(-1,2))
+    # numpy.savetxt('g0_w_diff.dat', (g0_w_fft - g0_w).view(float).reshape(-1,2))
+
+    assert numpy.allclose(g0_w_fft, g0_w, atol=1e-3)
+
+    # test for w2t
+
+    g0_t_fft = _fft_fermion_w2t(g0_w, beta, a=a)
+
+    # numpy.savetxt('g0_t.dat', g0_t)
+    # numpy.savetxt('g0_t_fft.dat', g0_t_fft)
+    # numpy.savetxt('g0_t_diff.dat', g0_t_fft - g0_t)
+
+    assert numpy.allclose(g0_t_fft, g0_t, atol=1e-3)


### PR DESCRIPTION
A new parameter ``no_tail_fit`` is introduced in [system] block. The occupation number is computed without tail fitting, if ``no_tail_fit=True`` is specified.

A no-tail-fit Fourier transform is implemented, but not used yet.