### PR TITLE
Support basis_rotation in CTHYB-SEGMENT solver

### DIFF
--- a/src/dcore/impurity_solvers/alps_cthyb_seg.py
+++ b/src/dcore/impurity_solvers/alps_cthyb_seg.py
@@ -271,7 +271,6 @@ class ALPSCTHYBSEGSolver(SolverBase):
 
         # (0) Rotate H0 and Delta_tau if rot is given
         g0_iw_rotated = self._G0_iw.copy()
-        print(type(g0_iw_rotated))
         if rot is None:
             u_mat_rotated = self.u_mat
         else:

--- a/src/dcore/impurity_solvers/alps_cthyb_seg.py
+++ b/src/dcore/impurity_solvers/alps_cthyb_seg.py
@@ -437,6 +437,9 @@ class ALPSCTHYBSEGSolver(SolverBase):
             key = (i1, i2, i3, i4)
             val = numpy.ndarray(n_w2b)
         """
+        if rot is not None:
+            # TODO
+            raise NotImplementedError
 
         use_chi_loc = False
 

--- a/src/dcore/impurity_solvers/alps_cthyb_seg.py
+++ b/src/dcore/impurity_solvers/alps_cthyb_seg.py
@@ -22,7 +22,7 @@ import sys
 from itertools import product
 from dcore._dispatcher import *
 from ..tools import make_block_gf, launch_mpi_subprocesses, extract_H0, umat2dd, get_block_size, expand_path
-from .base import SolverBase
+from .base import SolverBase, rotate_basis
 
 
 def to_numpy_array(g, names):
@@ -269,11 +269,20 @@ class ALPSCTHYBSEGSolver(SolverBase):
         #   self.n_flavor
         #   self.gf_struct
 
+        # (0) Rotate H0 and Delta_tau if rot is given
+        g0_iw_rotated = self._G0_iw.copy()
+        print(type(g0_iw_rotated))
+        if rot is None:
+            u_mat_rotated = self.u_mat
+        else:
+            assert isinstance(rot, dict)
+            u_mat_rotated = rotate_basis(rot, self.use_spin_orbit, self.u_mat, [g0_iw_rotated,], direction='forward')
+
         # (1a) If H0 is necessary:
         # Non-interacting part of the local Hamiltonian including chemical potential
         # Make sure H0 is hermite.
         # Ordering of index in H0 is spin1, spin1, ..., spin2, spin2, ...
-        H0 = extract_H0(self._G0_iw, self.block_names)
+        H0 = extract_H0(g0_iw_rotated, self.block_names)
 
         # from (up,orb1), (up,orb2), ..., (down,orb1), (down,orb2), ...
         # to (up,orb1), (down,orb1), (up,orb2), (down,orb2), ...
@@ -287,7 +296,7 @@ class ALPSCTHYBSEGSolver(SolverBase):
         # Compute the hybridization function from G0:
         #     Delta(iwn_n) = iw_n - H0 - G0^{-1}(iw_n)
         # H0 is extracted from the tail of the Green's function.
-        self._Delta_iw = delta(self._G0_iw)
+        self._Delta_iw = delta(g0_iw_rotated)
         Delta_tau = make_block_gf(GfImTime, self.gf_struct, self.beta, self.n_tau)
         for name in self.block_names:
             Delta_tau[name] << Fourier(self._Delta_iw[name])
@@ -308,22 +317,6 @@ class ALPSCTHYBSEGSolver(SolverBase):
 
         # TODO: check Delta_tau_data
         #    Delta_{ab}(tau) should be diagonal, real, negative
-
-        # rotate H0 and Delta_tau if rot is given
-        if rot is not None:
-            raise ValueError("basis_rotation is not supported in alps_cthyb_seg")
-
-            # rot^H . H0 . rot
-            # rot_mat = numpy.zeros((2*self.n_orb, 2*self.n_orb), dtype=complex)
-            # if self.use_spin_orbit:
-            #     rot_mat_4dim = rot_mat.reshape((1, 2*self.n_orb, 1, 2*self.n_orb))
-            # else:
-            #     rot_mat_4dim = rot_mat.reshape((2, self.n_orb, 2, self.n_orb))
-            # for sp, name in enumerate(self.block_names):
-            #     # rot_mat[sp*self.n_orb:(sp+1)*self.n_orb, sp*self.n_orb:(sp+1)*self.n_orb] = rot[name]
-            #     rot_mat_4dim[sp, :, sp, :] = rot[name]
-            # H0_diag = numpy.dot(rot_mat.conjugate().T, numpy.dot(H0, rot_mat))
-            # print(H0_diag)
 
         # (1c) Set U_{ijkl} for the solver
         # Set up input parameters and files for ALPS/CTHYB-SEG
@@ -362,7 +355,7 @@ class ALPSCTHYBSEGSolver(SolverBase):
                     print(' {:.15e}'.format(Delta_tau_data[itau, f1, f1].real), file=f, end="")
                 print("", file=f)
 
-        U, Uprime, J = dcore2alpscore(self.u_mat)
+        U, Uprime, J = dcore2alpscore(u_mat_rotated)
         write_Umatrix(U, Uprime, J, self.n_orb)
 
         with open('./MUvector', 'w') as f:
@@ -410,6 +403,11 @@ class ALPSCTHYBSEGSolver(SolverBase):
 
         set_blockgf_from_h5(self._Sigma_iw, "S_omega")
         set_blockgf_from_h5(self._Gimp_iw, "G_omega")
+
+        # Rotate Sigma and Gimp back to the original basis
+        if rot is not None:
+            rotate_basis(rot, self.use_spin_orbit, None, [self._Sigma_iw, self._Gimp_iw], direction='backward')
+            # rotate_basis(rot, self.use_spin_orbit, None, self._Gimp_iw, direction='backward')
 
         #   self.quant_to_save['nn_equal_time']
         nn_equal_time = self._get_results("nn", 1, orbital_symmetrize=True, stop_if_data_not_exist=False)

--- a/src/dcore/impurity_solvers/base.py
+++ b/src/dcore/impurity_solvers/base.py
@@ -102,7 +102,7 @@ class SolverBase(object):
         self._G0_iw << new_G0_iw.copy()
 
     def get_G0_iw(self):
-        return self._G0w_iw.copy()
+        return self._G0_iw.copy()
 
     def get_Sigma_iw(self):
         return self._Sigma_iw.copy()


### PR DESCRIPTION
An input like below now works:
```
[impurity_sover]
name = ALPS/cthyb-seg
basis_rotation = Hloc
```