### PR TITLE
New option dc_orbital_average in [system]

### DIFF
--- a/src/dcore/dmft_core.py
+++ b/src/dcore/dmft_core.py
@@ -230,7 +230,7 @@ def solve_impurity_model(solver_name, solver_params, mpirun_command, basis_rot, 
     return r
 
 
-def calc_dc(dc_type, u_mat, dens_mat, spin_block_names, use_spin_orbit):
+def calc_dc(dc_type, u_mat, dens_mat, spin_block_names, use_spin_orbit, dc_orbital_average):
 
     # dim_tot is the dimension of spin x orbit for SO = 1 or that of orbital for SO=0
     # dim_tot = self._dim_sh[ish]
@@ -284,6 +284,15 @@ def calc_dc(dc_type, u_mat, dens_mat, spin_block_names, use_spin_orbit):
                 dc_imp_sh[sp] = numpy.identity(num_orb) * dc
     else:
         raise ValueError("Here should not be reached")
+
+    #
+    # Average over orbitals
+    #
+    if dc_orbital_average:
+        for sp, dc_imp in dc_imp_sh.items():
+            dim = dc_imp.shape[0]
+            dc_ave = numpy.trace(dc_imp) / dim
+            dc_imp_sh[sp] = numpy.identity(dim) * dc_ave
 
     return dc_imp_sh
 
@@ -693,7 +702,8 @@ class DMFTCoreSolver(object):
         """
 
         dc_type = self._params['system']['dc_type']
-        print("\n  set DC (dc_type = {})".format(dc_type))
+        dc_orbital_average = self._params['system']['dc_orbital_average']
+        print(f"\n  set DC (dc_type = {dc_type}, dc_orbital_average = {dc_orbital_average})")
 
         def print_matrix(mat):
             dim = mat.shape[0]
@@ -727,7 +737,7 @@ class DMFTCoreSolver(object):
                 print_matrix(dens_mat[sp1][0:num_orb, 0:num_orb])
 
             # calculated DC
-            _dc_imp.append(calc_dc(dc_type, u_mat, dens_mat, self.spin_block_names, self._use_spin_orbit))
+            _dc_imp.append(calc_dc(dc_type, u_mat, dens_mat, self.spin_block_names, self._use_spin_orbit, dc_orbital_average))
 
             # print DC self energy
             print("\n      DC Self Energy:")

--- a/src/dcore/dmft_core.py
+++ b/src/dcore/dmft_core.py
@@ -734,7 +734,7 @@ class DMFTCoreSolver(object):
             print("\n      Local Density Matrix:".format(ish))
             for sp1 in self._spin_block_names:
                 print("        Spin {0}".format(sp1))
-                print_matrix(dens_mat[sp1][0:num_orb, 0:num_orb])
+                print_matrix(dens_mat[sp1])
 
             # calculated DC
             _dc_imp.append(calc_dc(dc_type, u_mat, dens_mat, self.spin_block_names, self._use_spin_orbit, dc_orbital_average))

--- a/src/dcore/program_options.py
+++ b/src/dcore/program_options.py
@@ -90,8 +90,9 @@ def create_parser(target_sections=None):
     parser.add_option("system", "mu", float, 0.0, "Initial chemical potential.")
     parser.add_option("system", "prec_mu", float, 0.0001,
                       "Threshold for calculating chemical potential with the bisection method.")
-    parser.add_option("system", "with_dc", bool, False, "Whether or not use double-counting correction (See below)")
+    parser.add_option("system", "with_dc", bool, False, "Whether or not to use double-counting (DC) correction (See below)")
     parser.add_option("system", "dc_type", str, 'HF_DFT', "Chosen from 'HF_DFT' (default), 'HF_imp', 'FLL'")
+    parser.add_option("system", "dc_orbital_average", bool, False, "If true, the DC correction is averaged over orbitals in each shell")
     parser.add_option("system", "no_tail_fit", bool, False, "Compute Matsubara summation without fitting high-frequency moments.")
 
     # [impurity_solver]

--- a/src/dcore/program_options.py
+++ b/src/dcore/program_options.py
@@ -92,7 +92,7 @@ def create_parser(target_sections=None):
                       "Threshold for calculating chemical potential with the bisection method.")
     parser.add_option("system", "with_dc", bool, False, "Whether or not to use double-counting (DC) correction (See below)")
     parser.add_option("system", "dc_type", str, 'HF_DFT', "Chosen from 'HF_DFT' (default), 'HF_imp', 'FLL'")
-    parser.add_option("system", "dc_orbital_average", bool, False, "If true, the DC correction is averaged over orbitals in each shell")
+    parser.add_option("system", "dc_orbital_average", bool, False, "If true, the DC correction is averaged over orbitals in each shell. Off-diagonal components are dropped.")
     parser.add_option("system", "no_tail_fit", bool, False, "Compute Matsubara summation without fitting high-frequency moments.")
 
     # [impurity_solver]


### PR DESCRIPTION
When the following option is activated, the DC matrix is average over orbitals in each shell.
```
[system]
dc_orbital_average = True
```
The default is False.