### PR TITLE
Fix import importlib.util

### DIFF
--- a/src/dcore/_dispatcher.py
+++ b/src/dcore/_dispatcher.py
@@ -1,5 +1,5 @@
 import os, sys
-import importlib
+import importlib.util
 
 
 if 'DCORE_TRIQS_COMPAT' in os.environ and int(os.environ['DCORE_TRIQS_COMPAT']) == 1:


### PR DESCRIPTION
To avoid the following error in Python 3.11.5:
```
Traceback (most recent call last):
  File "/home/otsuki/venv/python3.11/dcore_e/bin/dcore_pre", line 5, in <module>
    from dcore.dcore_pre import run
  File "/home/otsuki/gitclones/dcore/src/dcore/dcore_pre.py", line 24, in <module>
    from dcore._dispatcher import HDFArchive
  File "/home/otsuki/gitclones/dcore/src/dcore/_dispatcher.py", line 22, in <module>
    if not importlib.util.find_spec(l):
           ^^^^^^^^^^^^^^
AttributeError: module 'importlib' has no attribute 'util'
```