### PR TITLE
Replace plt.clf with plt.close

### DIFF
--- a/src/dcore/dcore_check.py
+++ b/src/dcore/dcore_check.py
@@ -95,7 +95,7 @@ class DMFTCoreCheck(object):
 
     def __plot_init(self):
         if self.plot_called:
-            self.plt.clf()
+            self.plt.close()
             self.plt.figure(figsize=(8, 6))  # default
             return
         self.plot_called = True


### PR DESCRIPTION
Replaced ``plt.clf()`` with ``plt.close()`` to avoid the following runtime warning:
```
RuntimeWarning: More than 20 figures have been opened. Figures created through the pyplot interface (`matplotlib.pyplot.figure`) are retained until explicitly closed and may consume too much memory. (To control this warning, see the rcParam `figure.max_open_warning`). Consider using `matplotlib.pyplot.close()`.
```