### PR TITLE
Test on more envs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
       - run: echo "This job is now running on a ${{ runner.os }} server hosted by GitHub!"
       - run: echo "The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - run: echo "The ${{ github.repository }} repository has been cloned to the runner."
       - name: pytest
         run: |

--- a/.github/workflows/ci_dcorelib.yml
+++ b/.github/workflows/ci_dcorelib.yml
@@ -18,7 +18,7 @@ jobs:
             scipy: "1.11"
             python: "3.11"
           - os: ubuntu-latest
-            numpy: "2.0"
+            numpy: "1.26"
             scipy: "1.14"
             python: "3.12"
           #- os: ubuntu-latest

--- a/.github/workflows/ci_dcorelib.yml
+++ b/.github/workflows/ci_dcorelib.yml
@@ -10,16 +10,16 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            numpy: "1.24"
-            scipy: "1.6"
+            numpy: "1.24.4"
+            scipy: "1.6.3"
             python: "3.8"
           - os: ubuntu-latest
-            numpy: "1.26"
-            scipy: "1.11"
+            numpy: "1.26.4"
+            scipy: "1.11.4"
             python: "3.11"
           - os: ubuntu-latest
-            numpy: "1.26"
-            scipy: "1.14"
+            numpy: "1.26.4"
+            scipy: "1.11.4"
             python: "3.12"
           #- os: ubuntu-latest
             #numpy: auto

--- a/.github/workflows/ci_dcorelib.yml
+++ b/.github/workflows/ci_dcorelib.yml
@@ -6,20 +6,21 @@ jobs:
       ${{ matrix.os }}, python==${{ matrix.python }}, numpy==${{ matrix.numpy }}, scipy==${{ matrix.scipy }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest
-            numpy: 1.24
-            scipy: 1.6
-            python: 3.8
+            numpy: "1.24"
+            scipy: "1.6"
+            python: "3.8"
           - os: ubuntu-latest
-            numpy: 1.24
-            scipy: 1.6
-            python: 3.11
+            numpy: "1.26"
+            scipy: "1.11"
+            python: "3.11"
           - os: ubuntu-latest
-            numpy: 2.0
-            scipy: 1.14
-            python: 3.12
+            numpy: "2.0"
+            scipy: "1.14"
+            python: "3.12"
           #- os: ubuntu-latest
             #numpy: auto
             #scipy: auto

--- a/.github/workflows/ci_dcorelib.yml
+++ b/.github/workflows/ci_dcorelib.yml
@@ -18,7 +18,7 @@ jobs:
             #python: 3.9
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: apt
         if: ${{ runner.os == 'Linux' }}
         run: |
@@ -27,7 +27,7 @@ jobs:
       - uses: mpi4py/setup-mpi@v1
 
       - name: Set up python ${{ matrix.python }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
 

--- a/.github/workflows/ci_dcorelib.yml
+++ b/.github/workflows/ci_dcorelib.yml
@@ -10,8 +10,8 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            numpy: "1.24.4"
-            scipy: "1.6.3"
+            numpy: "1.24"
+            scipy: "1.6"
             python: "3.8"
           - os: ubuntu-latest
             numpy: "1.26.4"

--- a/.github/workflows/ci_dcorelib.yml
+++ b/.github/workflows/ci_dcorelib.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 jobs:
   build:
     name: |
-      ${{ matrix.os }}, numpy==${{ matrix.numpy }}, scipy==${{ matrix.scipy }}
+      ${{ matrix.os }}, python==${{ matrix.python }}, numpy==${{ matrix.numpy }}, scipy==${{ matrix.scipy }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -12,6 +12,14 @@ jobs:
             numpy: 1.24
             scipy: 1.6
             python: 3.8
+          - os: ubuntu-latest
+            numpy: 1.24
+            scipy: 1.6
+            python: 3.11
+          - os: ubuntu-latest
+            numpy: 2.0
+            scipy: 1.14
+            python: 3.12
           #- os: ubuntu-latest
             #numpy: auto
             #scipy: auto

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -18,18 +18,18 @@ jobs:
       uses: rlespinasse/github-slug-action@v3.x
 
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         path: main
 
     - name: Checkout gh-pages
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         ref: gh-pages
         path: gh-pages
 
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
         python-version: 3.8
 

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -22,12 +22,12 @@ jobs:
         uses: rlespinasse/github-slug-action@v3.x
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: main
     
       - name: Checkout gh-pages
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: gh-pages
           path: gh-pages

--- a/.github/workflows/examples_dcorelib.yml
+++ b/.github/workflows/examples_dcorelib.yml
@@ -22,12 +22,12 @@ jobs:
         uses: rlespinasse/github-slug-action@v3.x
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: main
     
       - name: Checkout gh-pages
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: gh-pages
           path: gh-pages

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -11,7 +11,7 @@ jobs:
     name: Build source distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Build dist
         run: python setup.py sdist bdist_wheel


### PR DESCRIPTION
New environments are added -- Python 3.11 and Python 3.12.

I found the following;
- Numpy 2.0 does not work (we should fix later)
- Scipy >= 1.13 does not work because of dcore_lib
- Scipy 1.12.0 is not compatible with osqp (this is required by cvxpy?)

So, Numpy 1.26.4 and Scipy 1.11.4 are tested for Python 3.11 and 3.12