### PR TITLE
docker-compose command has been removed from GitHub Actions hosted runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,5 +16,5 @@ jobs:
           export LOCAL_GID=$(id -g $USER)
           echo "LOCAL_UID=${LOCAL_UID}" > .env
           echo "LOCAL_GID=${LOCAL_GID}" >> .env
-          docker-compose up -d dcoretest
+          docker compose up -d dcoretest
       - run: echo "This job's status is ${{ job.status }}."

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -39,7 +39,7 @@ jobs:
           export LOCAL_GID=$(id -g $USER)
           echo "LOCAL_UID=${LOCAL_UID}" > .env
           echo "LOCAL_GID=${LOCAL_GID}" >> .env
-          docker-compose up -d examples
+          docker compose up -d examples
           # Manually execute entrypoint script until the environmet is set up correctly
           docker exec examples-container bash -c '/entrypoint-examples.sh'
           docker exec examples-container bash -c 'cd examples; ls -l'

--- a/.github/workflows/examples_dcorelib.yml
+++ b/.github/workflows/examples_dcorelib.yml
@@ -39,7 +39,7 @@ jobs:
           export LOCAL_GID=$(id -g $USER)
           echo "LOCAL_UID=${LOCAL_UID}" > .env
           echo "LOCAL_GID=${LOCAL_GID}" >> .env
-          docker-compose up -d examples
+          docker compose up -d examples
           # Manually execute entrypoint script until the environmet is set up correctly
           docker exec examples-container bash -c '/entrypoint-examples.sh'
           docker exec examples-container bash -c 'cd examples; ls -l'

--- a/bin/deploy_examples.sh
+++ b/bin/deploy_examples.sh
@@ -1,1 +1,1 @@
-docker-compose up --build --force-recreate examples
+docker compose up --build --force-recreate examples


### PR DESCRIPTION
Replace `docker-compose` with `docker compose` (hyphen removed)

ref: https://engineering.nifty.co.jp/blog/26217 (in Japanese) and https://github.com/actions/runner-images/issues/9557