### PR TITLE
use dcorelib when triqs is not installed

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -11,12 +11,6 @@ Prerequisites
 
 #. Python3
 
-#. `TRIQS 3.x <https://triqs.github.io/triqs/>`_ and `TRIQS/DFTTools 3.x <https://triqs.github.io/dft_tools/>`_.
-    They must be installed prior to installing all other programs.
-    The current version of DCore supports TRIQS 3.x.
-    Please make sure that the triqs and triqs_dft_tools modules are loadable in your Python environment.
-    You may use `MateriAppsInstaller <https://github.com/wistaria/MateriAppsInstaller>`_, a collection of install scripts, to install prerequisites (TRIQS).
-
 #. You will also need at least one impurity solver.
 
    For example, the following programs are supported:
@@ -25,28 +19,36 @@ Prerequisites
    * :doc:`ALPS/CT-HYB<impuritysolvers/alpscore_cthyb/cthyb>`
    * :doc:`ALPS/CT-HYB-SEGMENT<impuritysolvers/alpscore_ctseg/ctseg>`
    * :doc:`TRIQS/cthyb<impuritysolvers/triqs_cthyb/cthyb>`
+   * :doc:`Pomerol solver<impuritysolvers/pomerol/pomerol>`
 
    We recommend to use the Hubbard-I solver for tests because this is fast.
    See :doc:`impuritysolvers` for a complete list of supported impurity solvers and their user manuals.
+
+#. [OPTIONAL] `TRIQS 3.x <https://triqs.github.io/triqs/>`_ and `TRIQS/DFTTools 3.x <https://triqs.github.io/dft_tools/>`_.
+
+   TRIQS can improve the performance of DCore.
+   The current version of DCore supports TRIQS 3.x.
+   Please make sure that the triqs and triqs_dft_tools modules are loadable in your Python environment.
+   You may use `MateriAppsInstaller <https://github.com/wistaria/MateriAppsInstaller>`_, a collection of install scripts, to install prerequisites (TRIQS).
+   If you installed TRIQS but want not to use it, please set the environment variable "DCORE_TRIQS_COMPAT" to "1" as follows.
+
+   .. code-block:: bash
+         
+      $ export DCORE_TRIQS_COMPAT=1
 
 
 Installation
 ------------------
 
+(NOTE: Using a virtual environment such as `venv <https://docs.python.org/3/library/venv.html>`_ is recommended to avoid conflicts with other Python packages.)
+
 You can install the latest version of DCore using ``pip`` command as follows.
 
    ::
 
-     $ pip3 install dcore -U
+      $ pip3 install dcore -U
 
 Here, ``-U`` stands for ''Upgrade''. The installed packages are upgraded to the latest version, if you already have packages installed.
-Further, if you do not have root privileges, you need to add ``--user`` option as
-
-   ::
-
-     $ pip3 install dcore -U --user
-
-Then, the packages are installed into .local directory in your home directory. Make sure that **$HOME/.local/bin** is included in PATH environment variable.
 
 
 Installation (only for developers)
@@ -81,12 +83,6 @@ You can download the source files in two ways.
 
       $ pip3 install .
 
-  If you do not have root privileges, please try
-
-  .. code-block:: bash
-
-      $ pip3 install . --user
-
   If both of them did not work, you could build a binary package and install it as follows
 
   .. code-block:: bash
@@ -96,17 +92,6 @@ You can download the source files in two ways.
       $ pip3 install dist/dcore-*.whl
 
   One can run unit tests using the installed DCore by executing the following commands.
-
-  Executables such as dcore_pre may be installed into $HOME/.local/bin/dcore if you install DCore with the "--user" option.
-  Please add this directory to your PATH environment if needed.
-
-  You can build documentations as follows.
-
-  .. code-block:: bash
-
-     $ pip3 install sphinx wild_sphinx_theme matplotlib
-     $ python3 -m dcore.option_tables doc/reference
-     $ sphinx-build -b html doc html
 
   Non-MPI tests can be run as follows.
 
@@ -132,3 +117,11 @@ You can download the source files in two ways.
 
   Note that it is not allowed to run MPI programs interactively on some system.
   In this case, please run MPI tests as a parallel job with one process.
+
+  You can build documentations as follows.
+
+  .. code-block:: bash
+
+     $ pip3 install sphinx wild_sphinx_theme matplotlib
+     $ python3 -m dcore.option_tables doc/reference
+     $ sphinx-build -b html doc html

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -30,11 +30,11 @@ Prerequisites
    The current version of DCore supports TRIQS 3.x.
    Please make sure that the triqs and triqs_dft_tools modules are loadable in your Python environment.
    You may use `MateriAppsInstaller <https://github.com/wistaria/MateriAppsInstaller>`_, a collection of install scripts, to install prerequisites (TRIQS).
-   If you installed TRIQS but want not to use it, please set the environment variable "DCORE_TRIQS_COMPAT" to "1" as follows.
+   If you want to use TRIQS, please set an environment variable ``DCORE_TRIQS_COMPAT`` to 0.
 
    .. code-block:: bash
          
-      $ export DCORE_TRIQS_COMPAT=1
+      $ export DCORE_TRIQS_COMPAT=0
 
 
 Installation

--- a/src/dcore/_dispatcher.py
+++ b/src/dcore/_dispatcher.py
@@ -2,7 +2,7 @@ import os, sys
 import importlib.util
 
 
-if 'DCORE_TRIQS_COMPAT' in os.environ and int(os.environ['DCORE_TRIQS_COMPAT']) == 1:
+if int(os.environ.get('DCORE_TRIQS_COMPAT', 1)) == 1:
     TRIQS_COMPAT = True
     from dcorelib.triqs_compat import *
     from dcorelib.triqs_compat import h5

--- a/src/dcore/_dispatcher.py
+++ b/src/dcore/_dispatcher.py
@@ -1,30 +1,10 @@
 import os, sys
 import importlib.util
 
-TRIQS_FOUND = True
-
-triqs_libs = ['triqs', 'triqs_dft_tools']
-for l in triqs_libs:
-    if not importlib.util.find_spec(l):
-        TRIQS_FOUND = False
-
-if "DCORE_TRIQS_COMPAT" in os.environ:
-    dtc = os.environ["DCORE_TRIQS_COMPAT"]
-    if dtc == "1":
-        TRIQS_COMPAT = True
-    else:
-        TRIQS_COMPAT = False
-
-    if TRIQS_FOUND and TRIQS_COMPAT:
-        print("INFO: TRIQS is found but DCORE_TRIQS_COMPAT is set to 1.")
-        print("      dcorelib.triqs_compat will be used")
-
-    if not TRIQS_FOUND and not TRIQS_COMPAT:
-        print("ERROR: TRIQS is required (DCORE_TRIQS_COMPAT={}) but TRIQS is not found!".format(dtc))
-        sys.exit(1)
+if "DCORE_TRIQS_COMPAT" in os.environ and os.environ["DCORE_TRIQS_COMPAT"] == "0":
+    TRIQS_COMPAT = False
 else:
-    TRIQS_COMPAT = not TRIQS_FOUND
-
+    TRIQS_COMPAT = True
 
 if TRIQS_COMPAT:
     from dcorelib.triqs_compat import *
@@ -39,6 +19,16 @@ if TRIQS_COMPAT:
     from dcorelib.triqs_compat.dft_tools import SumkDFT, SumkDFTTools
     from dcorelib.triqs_compat.plot import mpl_interface
 else:
+    triqs_libs = ['triqs', 'triqs_dft_tools']
+    for l in triqs_libs:
+        if not importlib.util.find_spec(l):
+            sys.exit("ERROR: TRIQS library is not found. Please install TRIQS library or set DCORE_TRIQS_COMPAT=1")
+
+    from triqs.version import version as triqs_version
+
+    if not "2" < triqs_version[0] < "4":
+        sys.exit("ERROR: TRIQS version {} is not supported. Please install TRIQS version 3.x".format(triqs_version))
+    
     from triqs.gf.gf import *
     from triqs.gf import *
     from h5 import *
@@ -53,4 +43,4 @@ else:
     else:
         from .backend import _triqs_mpi as mpi
 
-    print("INFO: TRIQS library is used")
+    print("INFO: TRIQS library {} is used".format(triqs_version))


### PR DESCRIPTION
~When TRIQS is not installed, `dcorelib.triqs_compat` will be used.~
~If you want to use `dcorelib.triqs_compat` when TRIQS is installed, set an environment variable `DCORE_TRIQS_COMPAT=1`~

By default, use `dcorelib.triqs_compat`.
If you want to use TRIQS library, set an environment variable `DCORE_TRIQS_COMPAT=0` explicitely.