### PR TITLE
Use cvxpy's default solver

### DIFF
--- a/src/dcore/anacont/spm.py
+++ b/src/dcore/anacont/spm.py
@@ -100,7 +100,7 @@ def get_single_continuation(
     sum_rule_const,
     lambd,
     verbose=True,
-    solver="ECOS",
+    solver="",
     solver_opts={},
 ):
     U, S, Vt, delta_energy, energies_extract = _get_svd_for_continuation(
@@ -134,7 +134,7 @@ def get_multiple_continuations(
     sum_rule_const,
     lambdas,
     verbose=True,
-    solver="ECOS",
+    solver="",
     solver_opts={},
 ):
     U, S, Vt, delta_energy, energies_extract = _get_svd_for_continuation(
@@ -210,7 +210,7 @@ def _solveProblem(
     sum_rule_const,
     lambd,
     verbose=True,
-    solver="ECOS",
+    solver="",
     solver_opts={},
 ):
     Q = len(S)
@@ -227,7 +227,10 @@ def _solveProblem(
     ]  # uniform real energy grid is assumed here
 
     prob = cp.Problem(objective, constraints)
-    _ = prob.solve(verbose=verbose, solver=solver, **solver_opts)
+    if solver == "":
+        _ = prob.solve(verbose=verbose)
+    else:
+        _ = prob.solve(verbose=verbose, solver=solver, **solver_opts)
     gf_tau_fit = np.dot(U, np.dot(Smat, rho_prime.value))
     chi2 = 0.5 * np.linalg.norm(gf_tau - gf_tau_fit, ord=2) ** 2
     return rho_prime.value, gf_tau_fit, chi2

--- a/src/dcore/program_options.py
+++ b/src/dcore/program_options.py
@@ -152,7 +152,7 @@ def create_parser(target_sections=None):
     parser.add_option("post.anacont.spm", "n_tail", int, 10, "number of matsubara points for tail-fitting")
     parser.add_option("post.anacont.spm", "n_sv", int, 50, "number of singular values to be used")
     parser.add_option("post.anacont.spm", "lambda", float, 1e-5, "coefficient of L1 regularization")
-    parser.add_option("post.anacont.spm", "solver", str, "ECOS", "solver to be used")
+    parser.add_option("post.anacont.spm", "solver", str, "", "solver to be used")
     parser.add_option("post.anacont.spm", "verbose_opt", bool, False, "show optimization progress")
     parser.add_option("post.anacont.spm", "show_fit", bool, False, "plot result of tail-fitting")
 

--- a/tests/non-mpi/anacont_spm/anacont_spm.py
+++ b/tests/non-mpi/anacont_spm/anacont_spm.py
@@ -193,7 +193,7 @@ def test_solveProblem():
 
     U, S, Vt, delta_energy, energies_extract = _get_svd_for_continuation(tau_grid, nsv, beta, emin, emax, num_energies)
 
-    rho_prime, gf_tau_fit, chi2 = _solveProblem(delta_energy, U, S, Vt, gf_tau, b_test, lambd, verbose=False, solver='ECOS')
+    rho_prime, gf_tau_fit, chi2 = _solveProblem(delta_energy, U, S, Vt, gf_tau, b_test, lambd, verbose=False)
     rho = np.dot(Vt.T, rho_prime)
 
     d_bhatt = np.trapz(y=np.sqrt(np.multiply(rho, dos)), x=energies_extract)


### PR DESCRIPTION
The default value of `post.anacont.spm.solver` changes from 'ECOS' to '', which means that cvxpy's default solver will be used because cvxpy stops shipping ECOS from 1.6.