### PR TITLE
Enable to call exteral sumkdft class

### DIFF
--- a/src/dcore/sumkdft_workers/launcher.py
+++ b/src/dcore/sumkdft_workers/launcher.py
@@ -27,6 +27,8 @@ def run_sumkdft(runner_cls, model_file, work_dir, mpirun_command, params):
 
     :param runner_cls: str
        Name of subclass of SumkDFTWorker
+       If runner_cls is fully qualified name (e.g., `module.class`), module will be automatically imported.
+       Otherwise, the class is assumed to be in dcore.sumkdft_workers.all_workers.
     :param model_file: str
         HDF5 file
     :param work_dir: str

--- a/src/dcore/sumkdft_workers/mpi_main.py
+++ b/src/dcore/sumkdft_workers/mpi_main.py
@@ -14,11 +14,20 @@ if __name__ == '__main__':
         args = parser.parse_args()
 
         # Runner class
-        m = importlib.import_module('dcore.sumkdft_workers.all_workers')
-        cls = getattr(m, args.runner_cls)
+        m_cls = args.runner_cls.split('.')
+        if len(m_cls) == 1:
+            m = importlib.import_module('dcore.sumkdft_workers.all_workers')
+            cls = getattr(m, args.runner_cls)
+        else:
+            m = importlib.import_module('.'.join(m_cls[:-1]))
+            cls = getattr(m, m_cls[-1])
         runner = cls(args.model_hdf5_file, args.input_file, args.output_file)
         runner.run()
-
+    except ImportError as e:
+        print("Import error:", e)
+        import traceback
+        traceback.print_exc()
+        sys.exit(1)
 
     except Exception as e:
         print("Unexpected error:", e)


### PR DESCRIPTION
This PR enables DCore to use external workers without modifying DCore source code.

The first argument of `dcore.sumkdft_workers.launcher.run_sumkdft` is a class name of SumkDFT worker.
When the class name is fully qualified, e.g., `mymodule.myclass` the module will be automatically imported.
Otherwise, the class is assumed to belong to `dcore.sumkdft_workers.all_workers` module.