### PR TITLE
update dcore_anacont spm

### DIFF
--- a/doc/analytic_continuation/spm.ini
+++ b/doc/analytic_continuation/spm.ini
@@ -41,7 +41,7 @@ n_tau = 101
 n_tail = 5
 n_sv = 30
 lambda = 1e-5
-solver = ECOS
+solver = CLARABEL
 
 [post.anacont.spm.solver]
-max_iters{int} = 100
+max_iter{int} = 100

--- a/doc/reference/input.rst
+++ b/doc/reference/input.rst
@@ -130,16 +130,25 @@ This block includes parameters that are solely used by ``dcore_anacont``.
 [post.anacont.pade] block
 ---------------------------
 
-This block includes parameters that are solely used by ``dcore_anacont``.
+This block includes parameters that are solely used by ``dcore_anacont`` when ``solver = pade`` in ``[post.anacont]``.
 
 .. include:: post.anacont.pade_desc.txt
 
 [post.anacont.spm] block
 ---------------------------
 
-This block includes parameters that are solely used by ``dcore_anacont``.
+This block includes parameters that are solely used by ``dcore_anacont`` when ``solver = spm`` in ``[post.anacont]``.
 
 .. include:: post.anacont.spm_desc.txt
+
+[post.anacont.spm.solver] block
+---------------------------
+
+This block includes parameters that are solely used by ``dcore_anacont`` when ``solver = spm`` in ``[post.anacont]``.
+
+The parameters in this block are passed to cvxpy's ``solve`` function.
+Note that ``solver`` and ``verbose_opt`` in ``[post.anacont.spm]`` are used for the ``solver`` and ``verbose`` arguments of ``solve``, respectively, so don't specify them here.
+See `cvxpy's solver documentation <https://www.cvxpy.org/tutorial/solvers/index.html>`_ for details.
 
 [post.spectrum] block
 -----------------------

--- a/src/dcore/anacont/spm.py
+++ b/src/dcore/anacont/spm.py
@@ -228,7 +228,7 @@ def _solveProblem(
 
     prob = cp.Problem(objective, constraints)
     if solver == "":
-        _ = prob.solve(verbose=verbose)
+        _ = prob.solve(verbose=verbose, **solver_opts)
     else:
         _ = prob.solve(verbose=verbose, solver=solver, **solver_opts)
     gf_tau_fit = np.dot(U, np.dot(Smat, rho_prime.value))

--- a/src/dcore/program_options.py
+++ b/src/dcore/program_options.py
@@ -45,7 +45,7 @@ def create_parser(target_sections=None):
     Create a parser for all program options of DCore
     """
     if target_sections is None:
-        parser = TypedParser(['mpi', 'model', 'pre', 'system', 'impurity_solver', 'control', 'post', 'post.anacont', 'post.anacont.pade', 'post.anacont.spm', 'post.anacont.spm.solver', 'post.spectrum', 'post.check', 'bse', 'vertex', 'sparse_bse'])
+        parser = TypedParser(['mpi', 'model', 'pre', 'system', 'impurity_solver', 'control', 'post', 'post.anacont', 'post.anacont.pade', 'post.anacont.spm', 'post.anacont.spm.solver' 'post.spectrum', 'post.check', 'bse', 'vertex', 'sparse_bse'])
     else:
         parser = TypedParser(target_sections)
     
@@ -133,7 +133,7 @@ def create_parser(target_sections=None):
     parser.add_option("post.check", "omega_check", float, 0, "Maximum frequency for dcore_check. If not specified, a fixed number of Matsubara points are taken.")
 
     # [post.anacont]
-    parser.add_option("post.anacont", "solver", str, "pade", "Algorithm for analytic continuation (pade or spm)")
+    parser.add_option("post.anacont", "solver", str, "algorithm", "Algorithm for analytic continuation")
     parser.add_option("post.anacont", "omega_min", float, -1, "Minimum value of real frequency")
     parser.add_option("post.anacont", "omega_max", float, 1, "Max value of real frequency")
     parser.add_option("post.anacont", "Nomega", int, 100, "Number of real frequencies")
@@ -152,9 +152,13 @@ def create_parser(target_sections=None):
     parser.add_option("post.anacont.spm", "n_tail", int, 10, "number of matsubara points for tail-fitting")
     parser.add_option("post.anacont.spm", "n_sv", int, 50, "number of singular values to be used")
     parser.add_option("post.anacont.spm", "lambda", float, 1e-5, "coefficient of L1 regularization")
-    parser.add_option("post.anacont.spm", "solver", str, "", "solver to be used")
+    parser.add_option("post.anacont.spm", "solver", str, "", "cvxpy solver for solving spm. Empty string means default solver of cvxpy.")
     parser.add_option("post.anacont.spm", "verbose_opt", bool, False, "show optimization progress")
     parser.add_option("post.anacont.spm", "show_fit", bool, False, "plot result of tail-fitting")
+
+    # [post.anacont.spm.solver]
+    # Nothing to add here
+    # All parameters are passed to cvxpy solver
 
     # [post.spectrum]
 


### PR DESCRIPTION
- update reference manuals (input parameters)
	- added `[post.anacont.spm.solver]` block
- fix a bug that `[post.anacont.spm.solver]` is ignored when `solver` in `[post.anacont.spm]` is omit (use default CvxPy solver)