### PR TITLE
`post.anacont.spm.n_tau` can be omitted now

### DIFF
--- a/doc/analytic_continuation/spm.rst
+++ b/doc/analytic_continuation/spm.rst
@@ -31,7 +31,7 @@ The parameters for the SpM method are specified in the ``[post.anacont.spm]`` bl
    lambda = 1e-5
 
 ``n_matsubara`` is the number of Matsubara frequencies used. When it is larger than the number of the data obtained by the DMFT calculation, the number of the data is used.
-``n_tau`` is the number of imaginary time points.
+``n_tau`` is the number of imaginary time points. If negative or omitted, it will be determined from the size of :math:`\Sigma(i\omega_n)` .
 ``n_tail`` is the number of the last Matsubara frequencies used for the tail fitting, :math:`\Sigma(i\omega_n) \sim a/i\omega_n`.
 ``n_sv`` is the number of singular values used after truncation.
 ``lambda`` is the coefficient of the L1 regularization term in the optimization.

--- a/src/dcore/anacont/spm.py
+++ b/src/dcore/anacont/spm.py
@@ -319,6 +319,10 @@ def parameters_from_ini(inifile):
 def anacont(sigma_iw_npz, beta, mesh_w, params_spm, params_spm_solver):
 
     n_tau = params_spm["n_tau"]
+    if n_tau <= 0:
+        print(f"Negative value of n_tau is given ({n_tau}), so n_tau will be determined from the size of sigma_iw")
+        n_tau = sigma_iw_npz['data0'].shape[0] // 2
+    print(f"n_tau = {n_tau}")
     n_tail = params_spm["n_tail"]
     show_fit = params_spm["show_fit"]
     


### PR DESCRIPTION
If `n_tau <= 0`, `n_tau` will be determined from the size of `sigma_iw.npz`.
The default value of `n_tau` is -1.