### PR TITLE
Pade anacont with dcorelib<0.9.7 gives wrong result

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
         # Import h5py imports mpi4py automatically.
         'h5py!=2.10.0',
         'toml>=0.10',
-        'dcorelib>=0.9.1',
+        'dcorelib>=0.9.7',
         'sympy',
         'cvxpy'
         ],

--- a/src/dcore/_dispatcher.py
+++ b/src/dcore/_dispatcher.py
@@ -18,13 +18,18 @@ if TRIQS_COMPAT:
     from dcorelib.triqs_compat import mpi
     from dcorelib.triqs_compat.dft_tools import SumkDFT, SumkDFTTools
     from dcorelib.triqs_compat.plot import mpl_interface
+
+    from dcorelib import __version__ as backend_version
+
+    backend_lib = "dcorelib"
+
 else:
     triqs_libs = ['triqs', 'triqs_dft_tools']
     for l in triqs_libs:
         if not importlib.util.find_spec(l):
             sys.exit("ERROR: TRIQS library is not found. Please install TRIQS library or set DCORE_TRIQS_COMPAT=1")
 
-    from triqs.version import version as triqs_version
+    from triqs.version import version as backend_version
 
     if not "2" < triqs_version[0] < "4":
         sys.exit("ERROR: TRIQS version {} is not supported. Please install TRIQS version 3.x".format(triqs_version))
@@ -43,4 +48,6 @@ else:
     else:
         from .backend import _triqs_mpi as mpi
 
-    print("INFO: TRIQS library {} is used".format(triqs_version))
+    backend_lib = "TRIQS"
+
+print(f"INFO: {backend_lib} {backend_version} is used")

--- a/src/dcore/anacont/pade.py
+++ b/src/dcore/anacont/pade.py
@@ -16,9 +16,10 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
+import sys
 import numpy
 
-from dcore._dispatcher import MeshImFreq, GfReFreq, GfImFreq
+from dcore._dispatcher import MeshImFreq, GfReFreq, GfImFreq, backend_lib, backend_version
 from dcore.program_options import create_parser, parse_parameters
 
 
@@ -39,6 +40,10 @@ def _set_n_matsubara(omega_cutoff, beta, n_min, n_max):
 
 
 def anacont(sigma_iw_npz, beta, mesh_w, params_pade):
+    if backend_lib == "dcorelib" and backend_version < "0.9.7":
+        sys.exit("ERROR: Pade anacont solver with dcorelib (<0.9.7) gives wrong results.\n"
+                 "       Please update dcorelib to >= 0.9.7")
+
     iw_max = params_pade["iomega_max"]
     n_min = params_pade["n_min"]
     n_max = params_pade["n_max"]


### PR DESCRIPTION
The latest dcorelib (0.9.7) fixes the Pade anacont issue.
`dcore_anacont`  now stops when performing Pade anacont with old dcorelib.