### PR TITLE
ALPS/CT-HYB-segment doesn't store g2w_i_j with i<j

### DIFF
--- a/src/dcore/impurity_solvers/alps_cthyb_seg.py
+++ b/src/dcore/impurity_solvers/alps_cthyb_seg.py
@@ -220,13 +220,14 @@ class ALPSCTHYBSEGSolver(SolverBase):
             results = f["simulation"]["results"]
             for i1, i2 in product(range(2*self.n_orb), repeat=2):
                 if orbital_symmetrize and i1 < i2:
+                    # alps_cthyb does not save i1<i2 data because of symmetry.
                     continue
                 group = "%s_%d_%d" % (group_prefix, i1, i2)
                 if group in results:
                     array[i1, i2, :] = results[group]["mean"]["value"]
                 elif stop_if_data_not_exist:
                     raise Exception("data does not exist in sim.h5/simulation/results/{}. alps_cthyb might be old.".format(group))
-        if orbital_symmetrize:  # Only i1>i2 is computed in CTQMC.
+        if orbital_symmetrize: # restore i1<i2 data from i1>i2 data
             for i1 in range(2*self.n_orb):
                 for i2 in range(i1):
                     array[i2, i1, :] = array[i1, i2, :]


### PR DESCRIPTION
(This description is generated by Copilot.)

This pull request refactors how orbital symmetrization is handled when extracting results from CTQMC simulations in `src/dcore/impurity_solvers/alps_cthyb_seg.py`. The main improvement is to consistently apply orbital symmetrization when reading two-particle Green's function data, ensuring symmetry is enforced after data extraction rather than during iteration.

**Orbital symmetrization logic:**

* In `_get_results`, the logic for skipping redundant indices during data extraction has been streamlined, and the symmetrization step is now performed in a dedicated post-processing loop after reading the available data. This ensures that only the necessary values are read and symmetry is enforced consistently.

**Consistent symmetrization in calculations:**

* In `calc_Xloc_ph`, the calls to `_get_results` for `g2w_re` and `g2w_im` now explicitly enable orbital symmetrization. This change ensures that the computed two-particle Green's functions are always symmetrized, improving consistency across calculations.