### PR TITLE
HPhi solver: off-diagonal Gf fix, speedups, canonical & spin-orbit paths

### DIFF
--- a/doc/impuritysolvers.rst
+++ b/doc/impuritysolvers.rst
@@ -10,6 +10,7 @@ Impurity solvers
    impuritysolvers/jo_cthyb/jo_cthyb
    impuritysolvers/triqs_hubbard_one/hubbard_one
    impuritysolvers/pomerol/pomerol
+   impuritysolvers/hphi/hphi
    impuritysolvers/scipy/scipy
    impuritysolvers/null
    impuritysolvers/how_to_integrate

--- a/doc/impuritysolvers/hphi/hphi.rst
+++ b/doc/impuritysolvers/hphi/hphi.rst
@@ -1,0 +1,67 @@
+Exact diagonalization solver: ``HPhi``
+======================================
+
+``HPhi`` is a numerical exact-diagonalization / Lanczos program for quantum
+lattice models.
+``DCore`` provides an interface to ``HPhi`` to solve the effective impurity
+problem of DMFT with a discretized hybridization function (a finite number of
+bath sites).
+
+Features
+--------
+
+- Arbitrary temperature (the one-body Green's function is evaluated on the
+  Matsubara axis).
+
+- All interactions available in ``DCore`` are supported (the full
+  :math:`U_{ijkl}` tensor is passed to ``HPhi``).
+
+- With ``n_bath = 0`` the solver reduces to the Hubbard-I approximation.
+
+Install
+-------
+
+The following program needs to be installed:
+
+- `HPhi <https://github.com/issp-center-dev/HPhi>`_
+
+Make sure that the ``HPhi`` executable is available, and pass its path through
+the ``exec_path`` parameter below.
+
+How to use
+----------
+
+Mandatory parameters:
+
+::
+
+    [impurity_solver]
+    name = HPhi
+    exec_path{str} = /install_directory/bin/HPhi
+
+Optional parameters:
+
+::
+
+    [impurity_solver]
+    n_bath{int} = 0        # number of bath sites per spin-orbital (0 = Hubbard-I)
+    exct{int} = 1          # number of low-lying eigenstates used for the
+                           # finite-temperature Green's function
+    fit_gtol{float} = 1e-5 # tolerance of the bath-hybridization fitting
+
+Notes
+-----
+
+- ``n_bath`` controls the number of discretized bath sites that approximate the
+  hybridization function. Larger ``n_bath`` improves the approximation but
+  enlarges the many-body Hilbert space, whose dimension grows exponentially
+  with the total number of sites ``n_orb + n_bath``.
+
+- ``exct`` sets how many low-lying eigenstates are included in the
+  finite-temperature average. It should be large enough that the Boltzmann
+  weight of the highest computed state is negligible at the target temperature.
+
+- ``HPhi`` requires the number of MPI processes to be a power of four for the
+  eigenenergy calculation. If the requested number of processes is not a power
+  of four, ``DCore`` automatically falls back to the largest power of four for
+  that step and prints a warning.

--- a/doc/impuritysolvers/hphi/hphi.rst
+++ b/doc/impuritysolvers/hphi/hphi.rst
@@ -119,3 +119,63 @@ low-lying thermally-populated excitations.
    solvers, they must give the same self-energy for the same impurity model.
    Cross-checking ``HPhi`` against ``scipy/sparse`` on a small model is a good
    way to confirm that ``exct`` (and other settings) are adequate.
+
+
+Running HPhi in parallel
+------------------------
+
+``DCore`` launches ``HPhi`` through the MPI command defined in the ``[mpi]``
+section, where ``#`` is replaced by the number of processes passed to
+``dcore`` (``dcore --np N``)::
+
+    [mpi]
+    command = mpirun -np #
+
+The HPhi solver runs in two MPI phases:
+
+1. **Eigenvalue step** -- a single ``HPhi`` invocation that uses *all* ``np``
+   processes. ``HPhi`` requires this count to be a power of four; ``DCore``
+   automatically rounds down (with a warning) if it is not.
+
+2. **Green's-function step** -- many independent ``HPhi`` runs (one per
+   excitation). These are distributed by the two-level layout described above:
+   ``n_outer = np / n_procs_per_hphi`` runs execute concurrently, each launched
+   with ``n_procs_per_hphi`` MPI ranks. ``n_procs_per_hphi`` must be a power of
+   four.
+
+.. note::
+
+   With an **MPI-only** build of ``HPhi`` (one that must be started through the
+   MPI launcher), keep ``n_procs_per_hphi`` :math:`\geq` the smallest value your
+   launcher accepts (typically 1 via ``mpirun -np 1`` / ``srun -n 1``), and
+   prefer launching each Green's-function run through the launcher rather than
+   bare. Running many bare MPI executables concurrently can fail due to MPI
+   runtime resource clashes; going through the launcher (``n_procs_per_hphi``
+   selects ``n_inner`` ranks per run) avoids this.
+
+On a SLURM cluster (e.g. ISSP System B "ohtaka", 128 cores/node), set the
+launcher to ``srun`` and choose the split with ``n_procs_per_hphi``. A minimal
+job script that puts each Green's-function run on 4 ranks and runs
+``128 / 4 = 32`` of them concurrently per node looks like::
+
+    #!/bin/sh
+    #SBATCH -p i8cpu          # interactive queue for testing (adjust for production)
+    #SBATCH -N 1
+    #SBATCH -n 128
+    #SBATCH -t 0:30:00
+
+    module load <your HPhi / python environment>
+
+    # in the input file:
+    #   [mpi]
+    #   command = srun -n #
+    #   [impurity_solver]
+    #   name = HPhi
+    #   exec_path{str} = /path/to/mpi/HPhi
+    #   n_procs_per_hphi{int} = 4
+    dcore --np 128 input.ini
+
+Here ``dcore --np 128`` gives ``np = 128`` (a power of four) for the eigenvalue
+step, and the Green's-function step runs ``32`` HPhi instances of ``4`` ranks
+each. Start small (e.g. ``--np 4`` with ``n_procs_per_hphi = 4``) on the
+interactive queue to validate the setup before scaling up.

--- a/doc/impuritysolvers/hphi/hphi.rst
+++ b/doc/impuritysolvers/hphi/hphi.rst
@@ -49,6 +49,7 @@ Optional parameters:
                            # finite-temperature Green's function
     fit_gtol{float} = 1e-5 # tolerance of the bath-hybridization fitting
     exct_weight_threshold{float} = 1e-3   # threshold for the "exct too small" warning
+    n_procs_per_hphi{int} = 1             # MPI ranks per HPhi run in the Gf step
 
 Notes
 -----
@@ -67,6 +68,15 @@ Notes
   eigenenergy calculation. If the requested number of processes is not a power
   of four, ``DCore`` automatically falls back to the largest power of four for
   that step and prints a warning.
+
+- The one-body Green's function is computed from many independent HPhi runs
+  (one per excitation). These runs are parallelised in two levels: ``n_outer``
+  runs execute concurrently, each using ``n_procs_per_hphi`` MPI ranks, with
+  ``n_outer = np / n_procs_per_hphi``. The default ``n_procs_per_hphi = 1`` runs
+  each HPhi serially and executes ``np`` runs concurrently (the previous
+  behaviour). Increase ``n_procs_per_hphi`` (a power of four) when a single HPhi
+  run is heavy, e.g. with many bath sites; it trades concurrency for per-run MPI
+  speed. The total ``np`` is shared between the two levels.
 
 
 Choosing exct (degenerate ground states)

--- a/doc/impuritysolvers/hphi/hphi.rst
+++ b/doc/impuritysolvers/hphi/hphi.rst
@@ -131,32 +131,37 @@ section, where ``#`` is replaced by the number of processes passed to
     [mpi]
     command = mpirun -np #
 
-The HPhi solver runs in two MPI phases:
+The HPhi solver runs in two MPI phases, and **both use the same number of ranks
+per HPhi run**, ``n_procs_per_hphi`` (call it ``n_inner``):
 
-1. **Eigenvalue step** -- a single ``HPhi`` invocation that uses *all* ``np``
-   processes. ``HPhi`` requires this count to be a power of four; ``DCore``
-   automatically rounds down (with a warning) if it is not.
+1. **Eigenvalue step** -- a single ``HPhi`` run on ``n_inner`` ranks. It writes
+   the eigenvectors MPI-distributed (one file per rank).
 
 2. **Green's-function step** -- many independent ``HPhi`` runs (one per
-   excitation). These are distributed by the two-level layout described above:
-   ``n_outer = np / n_procs_per_hphi`` runs execute concurrently, each launched
-   with ``n_procs_per_hphi`` MPI ranks. ``n_procs_per_hphi`` must be a power of
-   four.
+   excitation), each on ``n_inner`` ranks, with ``n_outer = np / n_inner`` of
+   them executing concurrently.
 
-.. note::
+.. important::
 
-   With an **MPI-only** build of ``HPhi`` (one that must be started through the
-   MPI launcher), keep ``n_procs_per_hphi`` :math:`\geq` the smallest value your
-   launcher accepts (typically 1 via ``mpirun -np 1`` / ``srun -n 1``), and
-   prefer launching each Green's-function run through the launcher rather than
-   bare. Running many bare MPI executables concurrently can fail due to MPI
-   runtime resource clashes; going through the launcher (``n_procs_per_hphi``
-   selects ``n_inner`` ranks per run) avoids this.
+   The two phases **must** use the same rank count. The Green's-function step
+   reads back the eigenvectors written by the eigenvalue step, and an MPI-
+   distributed eigenvector can only be read by the same number of ranks that
+   wrote it. ``DCore`` therefore drives both phases with ``n_inner`` ranks; do
+   not expect the eigenvalue step to use all ``np``. ``n_inner`` must be a power
+   of four (an HPhi requirement); ``DCore`` rounds it down with a warning if it
+   is not. ``np`` itself need not be a power of four -- the remainder simply
+   sets ``n_outer``.
+
+So ``np = n_inner * n_outer``: choose ``n_inner`` (ranks per HPhi, a power of
+four) for how heavy a single HPhi run is, and let the rest of ``np`` provide
+concurrency across the many Green's-function runs. The default
+``n_procs_per_hphi = 1`` runs single-rank HPhi with ``np`` concurrent
+Green's-function runs (this reproduces the serial behaviour at ``np = 1``).
 
 On a SLURM cluster (e.g. ISSP System B "ohtaka", 128 cores/node), set the
-launcher to ``srun`` and choose the split with ``n_procs_per_hphi``. A minimal
-job script that puts each Green's-function run on 4 ranks and runs
-``128 / 4 = 32`` of them concurrently per node looks like::
+launcher to ``srun`` and pick ``n_inner`` with ``n_procs_per_hphi``. A job
+script that puts each HPhi run on 4 ranks and runs ``128 / 4 = 32`` of them
+concurrently per node looks like::
 
     #!/bin/sh
     #SBATCH -p i8cpu          # interactive queue for testing (adjust for production)
@@ -175,7 +180,7 @@ job script that puts each Green's-function run on 4 ranks and runs
     #   n_procs_per_hphi{int} = 4
     dcore --np 128 input.ini
 
-Here ``dcore --np 128`` gives ``np = 128`` (a power of four) for the eigenvalue
-step, and the Green's-function step runs ``32`` HPhi instances of ``4`` ranks
-each. Start small (e.g. ``--np 4`` with ``n_procs_per_hphi = 4``) on the
-interactive queue to validate the setup before scaling up.
+Here every HPhi run (eigenvalue step and each Green's-function run) uses 4
+ranks, and ``32`` Green's-function runs proceed concurrently. Start small
+(e.g. ``--np 4`` with ``n_procs_per_hphi = 4``) on the interactive queue to
+validate the setup before scaling up.

--- a/doc/impuritysolvers/hphi/hphi.rst
+++ b/doc/impuritysolvers/hphi/hphi.rst
@@ -158,29 +158,35 @@ concurrency across the many Green's-function runs. The default
 ``n_procs_per_hphi = 1`` runs single-rank HPhi with ``np`` concurrent
 Green's-function runs (this reproduces the serial behaviour at ``np = 1``).
 
-On a SLURM cluster (e.g. ISSP System B "ohtaka", 128 cores/node), set the
-launcher to ``srun`` and pick ``n_inner`` with ``n_procs_per_hphi``. A job
-script that puts each HPhi run on 4 ranks and runs ``128 / 4 = 32`` of them
-concurrently per node looks like::
+On ISSP System B "ohtaka" (Slurm, AMD EPYC 7702, 128 cores/node) HPhi is
+launched with ``srun``. Because the Green's-function step runs several ``srun``
+steps concurrently inside one job allocation, each must take its cores
+exclusively -- the Slurm "bulk job" pattern. Set the launcher accordingly::
+
+    [mpi]
+    command = srun --exclusive --mem-per-cpu=1840 -n #
+
+``--exclusive`` keeps the concurrent Green's-function runs off each other's
+cores, ``--mem-per-cpu=1840`` (MB) reserves the per-core share of a node's
+memory, and ``-n #`` is the rank count that ``DCore`` rewrites to ``n_inner``
+for every HPhi run. A batch script that puts each HPhi run on 4 ranks and runs
+``128 / 4 = 32`` of them concurrently on one node::
 
     #!/bin/sh
-    #SBATCH -p i8cpu          # interactive queue for testing (adjust for production)
-    #SBATCH -N 1
-    #SBATCH -n 128
+    #SBATCH -p i8cpu          # interactive/debug queue: <=8 nodes, 30 min, 1 running job
+    #SBATCH -N 1              # one node = 128 cores
     #SBATCH -t 0:30:00
 
-    module load <your HPhi / python environment>
+    module load <your HPhi / Python environment>
 
-    # in the input file:
-    #   [mpi]
-    #   command = srun -n #
-    #   [impurity_solver]
+    # [impurity_solver] in input.ini:
     #   name = HPhi
     #   exec_path{str} = /path/to/mpi/HPhi
     #   n_procs_per_hphi{int} = 4
     dcore --np 128 input.ini
 
-Here every HPhi run (eigenvalue step and each Green's-function run) uses 4
-ranks, and ``32`` Green's-function runs proceed concurrently. Start small
-(e.g. ``--np 4`` with ``n_procs_per_hphi = 4``) on the interactive queue to
-validate the setup before scaling up.
+Every HPhi run (eigenvalue step and each Green's-function run) then uses 4
+ranks, with 32 running concurrently. For quick checks grab a node interactively
+(``salloc -N 1 -p i8cpu``, then run ``dcore`` on the compute node). Start small
+(``--np 4`` with ``n_procs_per_hphi = 4``) before scaling up; use a longer queue
+such as ``F4cpu`` for production (``i8cpu`` is capped at 30 minutes).

--- a/doc/impuritysolvers/hphi/hphi.rst
+++ b/doc/impuritysolvers/hphi/hphi.rst
@@ -121,6 +121,95 @@ low-lying thermally-populated excitations.
    way to confirm that ``exct`` (and other settings) are adequate.
 
 
+Experimental: accelerated and spin-orbit Green's functions
+----------------------------------------------------------
+
+The one-body Green's function can optionally be computed by faster code paths,
+and spin-orbit-coupled impurities (spin-mixing one-body terms) are supported.
+These are **opt-in through environment variables** and leave the default
+behaviour unchanged.
+
+``DCORE_HPHI_CANONICAL_SECTORS=1`` uses only baseline ``HPhi`` functionality
+(standard canonical :math:`(N_e, 2S_z)` runs) and works with any ``HPhi``. The
+other switches need a more recent ``HPhi`` build, in increasing order:
+
+- the internal-loop path needs ``HPhi`` with the internal eigenstate loop for
+  the finite-temperature dynamical Green's function (``SpectrumLoopExct``, plus
+  ``SpectrumNumOp`` for the multi-operator batching);
+- the direct bra-ket path additionally needs the bra loop (``SpectrumNumBra``);
+- the spin-orbit (particle-number-only) path additionally needs the
+  ``HubbardNConserved`` single-excitation off-diagonal support.
+
+.. note::
+
+   As of this writing the internal-loop / bra-ket / ``HubbardNConserved``
+   ``HPhi`` features are pending release. With an older ``HPhi`` the switches
+   that need them will fail; leave them unset -- or use only
+   ``DCORE_HPHI_CANONICAL_SECTORS=1`` -- to stay on baseline functionality (the
+   default is the combination-trick, grand-canonical path).
+
+.. list-table::
+   :header-rows: 1
+   :widths: 34 66
+
+   * - Environment variable
+     - Effect
+   * - ``DCORE_HPHI_INTERNAL_LOOP=1``
+     - Within each Hilbert-sector batch, one ``HPhi`` launch sweeps all retained
+       eigenstates and the batched excitation operators, instead of one launch
+       per (eigenstate × operator). Removes the process-spawn and
+       eigenvector-reload overhead.
+   * - ``DCORE_HPHI_BRAKET=1``
+     - Direct bra/ket projection: one shifted-BiCG solve per ket operator is
+       projected onto every bra, so the off-diagonal :math:`G_{ij}` is read
+       directly instead of reconstructed from the :math:`c_i + i c_j`
+       combination. Cuts the BiCG count from :math:`n_\text{orb}^2` to
+       :math:`n_\text{orb}` per spin-conserving block (for the spin-orbit route
+       below, from :math:`(2 n_\text{orb})^2` to :math:`2 n_\text{orb}` over the
+       combined spin-orbitals). Implies the internal loop and the sector
+       restriction below.
+   * - ``DCORE_HPHI_CANONICAL_SECTORS=1``
+     - Restrict each excited-state solve to the relevant particle-number / spin
+       :math:`(N_e, 2S_z)` sector instead of the full grand-canonical Fock
+       space, shrinking the Hilbert space per solve. (Non-spin-orbit models.)
+   * - ``DCORE_HPHI_FORCE_NE_SECTORS=1``
+     - Use particle-number-only (``HubbardNConserved``) sectors, where both
+       spins share each :math:`N_e \pm 1` excited space. Automatically enabled
+       for spin-orbit models (where :math:`2S_z` is not conserved). Requires
+       ``DCORE_HPHI_BRAKET=1``.
+
+**Spin-orbit coupling.** When the calculation uses the combined spin-orbital
+representation -- a single ``ud`` block, i.e. ``spin_orbit = True`` -- ``DCore``
+selects the particle-number-only route (together with ``DCORE_HPHI_BRAKET=1``)
+and computes the full :math:`2\,n_\text{orb} \times 2\,n_\text{orb}` self-energy
+including the non-zero cross-spin blocks. This route is cross-validated against
+the independent ``scipy/sparse`` ED solver; the regression test asserts
+agreement below :math:`5\times10^{-3}` on a spin-flip crystal-field model. For a
+spin-orbit impurity, set ``DCORE_HPHI_BRAKET=1``.
+
+.. warning::
+
+   The particle-number-only route cannot run the empty (:math:`N_e = 0`) and
+   full (:math:`N_e = 2\,n_\text{site}`, where
+   :math:`n_\text{site} = n_\text{orb} + n_\text{bath}`) boundary sectors as
+   thermally occupied initial sectors, so the thermal trace omits the
+   contributions whose initial state lies in those two sectors. (Retained
+   sectors still reach the boundary excited spaces via their :math:`N_e \pm 1`
+   transitions.) The result
+   is therefore exact only when the near-empty and near-full sectors are
+   thermally negligible at the target temperature; ``DCore`` prints a warning
+   when it skips a boundary sector. This is generally safe for a partially
+   filled correlated impurity but can bias very small or nearly-empty/-full
+   models.
+
+.. tip::
+
+   For a large speedup on a recent ``HPhi`` build, set ``DCORE_HPHI_BRAKET=1``
+   alone -- it turns on the internal loop and the sector restriction as well.
+   As always, cross-check against ``scipy/sparse`` on a small model after
+   changing these switches.
+
+
 Running HPhi in parallel
 ------------------------
 

--- a/doc/impuritysolvers/hphi/hphi.rst
+++ b/doc/impuritysolvers/hphi/hphi.rst
@@ -48,6 +48,7 @@ Optional parameters:
     exct{int} = 1          # number of low-lying eigenstates used for the
                            # finite-temperature Green's function
     fit_gtol{float} = 1e-5 # tolerance of the bath-hybridization fitting
+    exct_weight_threshold{float} = 1e-3   # threshold for the "exct too small" warning
 
 Notes
 -----
@@ -60,8 +61,51 @@ Notes
 - ``exct`` sets how many low-lying eigenstates are included in the
   finite-temperature average. It should be large enough that the Boltzmann
   weight of the highest computed state is negligible at the target temperature.
+  See `Choosing exct (degenerate ground states)`_ below.
 
 - ``HPhi`` requires the number of MPI processes to be a power of four for the
   eigenenergy calculation. If the requested number of processes is not a power
   of four, ``DCore`` automatically falls back to the largest power of four for
   that step and prints a warning.
+
+
+Choosing exct (degenerate ground states)
+----------------------------------------
+
+``HPhi`` builds the finite-temperature Green's function from the lowest
+``exct`` eigenstates, weighting eigenstate :math:`n` by the Boltzmann factor
+:math:`e^{-\beta (E_n - E_0)}`.  If ``exct`` is too small, states that are still
+thermally relevant are left out of the trace and the resulting self-energy is
+**wrong**.
+
+.. warning::
+
+   The default ``exct = 1`` is unsafe for multi-orbital models.  Multi-orbital
+   impurities very often have a **degenerate ground state** (for example, one
+   electron in two degenerate orbitals is four-fold degenerate).  With
+   ``exct = 1`` only one member of the multiplet enters the thermal trace, which
+   **breaks the orbital symmetry** and yields a spurious, asymmetric self-energy
+   with non-zero off-diagonal components — even though the exact answer is
+   symmetric and diagonal.
+
+   Set ``exct`` large enough to cover the whole degenerate ground multiplet
+   *and* every excited state with a non-negligible Boltzmann weight at the
+   target temperature.  When in doubt, increase ``exct`` until the result stops
+   changing (for a tiny problem you may simply use the full Hilbert-space
+   dimension :math:`4^{\,\mathrm{n\_orb}+\mathrm{n\_bath}}`).
+
+To help catch this, ``DCore`` inspects the computed eigenenergies after the
+eigenvalue step and prints a warning when the highest computed state still
+carries a Boltzmann weight above ``exct_weight_threshold`` (default ``1e-3``) —
+i.e. when states above the ``exct`` cutoff are likely missing from the thermal
+trace.  The warning reports the ground-state degeneracy and the remaining
+weight; increase ``exct`` until it disappears.  This is a thermal
+**convergence** check, so it also fires for non-degenerate ground states with
+low-lying thermally-populated excitations.
+
+.. tip::
+
+   Because both ``HPhi`` and the ``scipy/sparse`` solver are exact-diagonalization
+   solvers, they must give the same self-energy for the same impurity model.
+   Cross-checking ``HPhi`` against ``scipy/sparse`` on a small model is a good
+   way to confirm that ``exct`` (and other settings) are adequate.

--- a/doc/impuritysolvers/hphi/hphi.rst
+++ b/doc/impuritysolvers/hphi/hphi.rst
@@ -142,8 +142,10 @@ other switches need a more recent ``HPhi`` build, in increasing order:
 
 .. note::
 
-   As of this writing the internal-loop / bra-ket / ``HubbardNConserved``
-   ``HPhi`` features are pending release. With an older ``HPhi`` the switches
+   These ``HPhi`` features (the internal eigenstate/operator/bra loop and the
+   ``HubbardNConserved`` off-diagonal support) are merged into the upstream
+   ``HPhi`` development branch and will ship in its next release; build ``HPhi``
+   from a recent source to use them now. With an older ``HPhi`` the switches
    that need them will fail; leave them unset -- or use only
    ``DCORE_HPHI_CANONICAL_SECTORS=1`` -- to stay on baseline functionality (the
    default is the combination-trick, grand-canonical path).

--- a/src/dcore/impurity_solvers/base.py
+++ b/src/dcore/impurity_solvers/base.py
@@ -310,7 +310,8 @@ def _rotate_basis(rot, u_matrix, use_spin_orbit, Gfs, X_dict, chi_dict):
 
         # X_{1234}(iW, iw, iw') = < c_1^+(iw) c_2(iw+iW) c_4^+(iw'+iW) c_3(iw') >
         array = numpy.einsum("ijklxyz,im,jn,ko,lp -> mnopxyz", array,
-                    rot_spin_full, numpy.conj(rot_spin_full), numpy.conj(rot_spin_full), rot_spin_full)
+                    rot_spin_full, numpy.conj(rot_spin_full), numpy.conj(rot_spin_full), rot_spin_full,
+                    optimize=True)
 
         X_dict.clear()
         _set_to_dict(X_dict, array)
@@ -323,14 +324,16 @@ def _rotate_basis(rot, u_matrix, use_spin_orbit, Gfs, X_dict, chi_dict):
 
         # chi_{1234}(iW) = < c_1^+ c_2 c_4^+ c_3 >(iW)
         array = numpy.einsum("ijklx,im,jn,ko,lp -> mnopx", array,
-                    rot_spin_full, numpy.conj(rot_spin_full), numpy.conj(rot_spin_full), rot_spin_full)
+                    rot_spin_full, numpy.conj(rot_spin_full), numpy.conj(rot_spin_full), rot_spin_full,
+                    optimize=True)
 
         chi_dict.clear()
         _set_to_dict(chi_dict, array)
 
     if not u_matrix is None:
         return numpy.einsum("ijkl,im,jn,ko,lp", u_matrix,
-                                    numpy.conj(rot_spin_full), numpy.conj(rot_spin_full), rot_spin_full, rot_spin_full)
+                                    numpy.conj(rot_spin_full), numpy.conj(rot_spin_full), rot_spin_full, rot_spin_full,
+                                    optimize=True)
 
 
 def _set_from_dict(x_dict, x_array):

--- a/src/dcore/impurity_solvers/hphi.py
+++ b/src/dcore/impurity_solvers/hphi.py
@@ -224,6 +224,30 @@ def enumerate_particle_sectors(n_site):
     return sectors
 
 
+def enumerate_ne_sectors(n_site):
+    """Enumerate the Ne-only sectors of a system of ``n_site`` sites (2*n_site spin-orbitals).
+
+    This is the coarser decomposition used when 2Sz is NOT conserved (spin-orbit coupling): the
+    Hamiltonian is block-diagonal in the total electron number Ne but mixes 2Sz, so one sectors by
+    Ne alone (all 2Sz merged). A sector is fixed in HPhi by writing ``Ncond = Ne`` and OMITTING
+    ``2Sz`` from the modpara, which makes HPhi select CalcModel = HubbardNConserved (Ne conserved,
+    Sz free). The dimension is ``C(2*n_site, Ne)`` (place Ne electrons among the 2*n_site
+    spin-orbitals, any spin), and ``sum(dim) == 4**n_site`` as a counting fact.
+
+    These sectors are larger than the (Ne, 2Sz) sectors (which they are the union of over 2Sz) but
+    still much smaller than the full grand-canonical 4**n_site space. Within one Ne sector both
+    spins live in the same Ne+-1 excited space, so the direct bra/ket path can obtain cross-spin
+    Green's-function elements -- which is why this is the spin-orbit-capable braket route.
+
+    Returns a list of dicts ``{'Ne', 'dim'}`` sorted by Ne.
+    """
+    from math import comb
+    if n_site < 0:
+        raise ValueError("n_site must be non-negative, got {}".format(n_site))
+    n_so = 2 * n_site  # number of spin-orbitals
+    return [{'Ne': ne, 'dim': comb(n_so, ne)} for ne in range(n_so + 1)]
+
+
 def gf_parallel_layout(mpirun_command, np_total, n_procs_per_hphi):
     """
     Decide the two-level parallel layout for the Gf (one-body Green's function) step.
@@ -475,11 +499,15 @@ class HPhiSolver(SolverBase):
         # per-(Ne, 2Sz) sector decomposition, so it implies the canonical path. Both require a
         # 2Sz-conserving (no spin-orbit) Hamiltonian.
         use_braket = os.environ.get("DCORE_HPHI_BRAKET", "0") == "1"
+        # Spin-orbit (2Sz broken, Ne still conserved): the bra/ket path falls back to the coarser
+        # Ne-only sector decomposition (HubbardNConserved), where both spins share the Ne+-1
+        # excited space so cross-spin G elements are obtained too. DCORE_HPHI_FORCE_NE_SECTORS=1
+        # forces this Ne-only route even without spin-orbit (testing / alternative decomposition):
+        # it must reproduce the (Ne, 2Sz) result for a 2Sz-conserving model.
+        force_ne = os.environ.get("DCORE_HPHI_FORCE_NE_SECTORS", "0") == "1"
+        use_ne_canonical = use_braket and (self.use_spin_orbit or force_ne)
         use_canonical = ((os.environ.get("DCORE_HPHI_CANONICAL_SECTORS", "0") == "1" or use_braket)
-                         and not self.use_spin_orbit)
-        if use_braket and self.use_spin_orbit:
-            raise RuntimeError("DCORE_HPHI_BRAKET=1 is not supported with spin-orbit coupling "
-                               "(2Sz must be conserved); use the default solver.")
+                         and not self.use_spin_orbit and not use_ne_canonical)
 
         if use_canonical:
             # H is block-diagonal in (Ne, 2Sz), so the grand-canonical finite-T trace equals the
@@ -575,6 +603,97 @@ class HPhiSolver(SolverBase):
             Z_global = sum(weights)
             one_body_g = sum(w * c[0] for w, c in zip(weights, contributions)) / Z_global
             print("\nFinish Gf calc ({} sectors).".format(len(contributions)))
+        elif use_ne_canonical:
+            # Spin-orbit: 2Sz is broken but Ne is conserved, so H is block-diagonal in Ne. Sector by
+            # Ne only (HubbardNConserved: Ncond set, 2Sz omitted) and recombine exactly as the
+            # (Ne, 2Sz) path. Each Ne sector's Ne+-1 excited space holds both spins, so the bra/ket
+            # path projects cross-spin elements too.
+            print("\nComputing eigenenergies + Gf per Ne sector (spin-orbit, HubbardNConserved) ...")
+            ne_calcmod = calcmod_def.replace("CalcModel   3", "CalcModel   0")
+            T_list = [1. / self.beta]
+            eta = 1e-4
+            sector_weight_threshold = params_kw.get('canonical_sector_weight_threshold', 1e-8)
+            if not (0.0 <= sector_weight_threshold < 1.0):
+                raise ValueError("canonical_sector_weight_threshold must be in [0, 1), got {}"
+                                 .format(sector_weight_threshold))
+
+            def run_ne_sector_eigenvalues(Ne, exct_use):
+                """Write a HubbardNConserved (Ncond, no 2Sz) modpara/calcmod and run the eigenvalue
+                step; HPhi auto-selects HubbardNConserved when 2Sz is omitted. Returns the energies."""
+                sector_modpara = modpara_def.format(n_site, exct_use, self.n_iw, omega_max, omega_min)
+                sector_modpara = sector_modpara.replace("LanczosTarget  2",
+                                                        "LanczosTarget  {}".format(min(2, exct_use)))
+                sector_modpara += "Ncond          {}\n".format(Ne)  # no 2Sz -> HubbardNConserved
+                with open('./modpara.def', 'w') as f:
+                    f.write(sector_modpara)
+                with open('./calcmod.def', 'w') as f:
+                    f.write(ne_calcmod)
+                with open('./stdout.log', 'w') as output_f:
+                    launch_mpi_subprocesses(mpirun_command_eigen, [exec_path, '-e', 'namelist.def'], output_f)
+                return read_eigenenergies(os.path.join('output', 'zvo_energy.dat'))
+
+            # Boundary-sector limitation of the Ne-only (HubbardNConserved) route: HPhi cannot run
+            # the vacuum sector (Ne = 0; it rejects Ncond = 0) nor, due to a HubbardNConserved
+            # Hilbert-construction (sz()) edge case, the fully occupied sector (Ne = 2*n_site).
+            # Both are single states (dim = 1). Dropping them makes the finite-T trace exact ONLY
+            # when neither boundary state carries appreciable Boltzmann weight -- i.e. the impurity
+            # is not near-empty or near-full. This holds for typical partial fillings but NOT in
+            # extreme chemical-potential / crystal-field regimes, where the result would be biased.
+            # It is therefore dropped EXPLICITLY (loud warning, not silent); an exact treatment of
+            # the two dim-1 edges is a known follow-up.
+            ne_lo, ne_hi = 1, 2 * n_site - 1
+            dropped = sorted({s['Ne'] for s in enumerate_ne_sectors(n_site)
+                              if min(exct, s['dim']) >= 1 and not (ne_lo <= s['Ne'] <= ne_hi)})
+            if dropped:
+                print("Warning: the spin-orbit (HubbardNConserved) bra/ket route cannot run the "
+                      "boundary Ne sectors {}; they are dropped. The finite-T trace is exact only "
+                      "if these near-empty/near-full states are thermally negligible (typical "
+                      "partial filling) -- verify the filling is not extreme.".format(dropped),
+                      file=sys.stderr)
+            all_sectors = [s for s in enumerate_ne_sectors(n_site)
+                           if min(exct, s['dim']) >= 1 and ne_lo <= s['Ne'] <= ne_hi]
+            if sector_weight_threshold > 0.0:
+                gs = []
+                for sec in all_sectors:
+                    e = run_ne_sector_eigenvalues(sec['Ne'], 1)
+                    if e.size > 0:
+                        gs.append((sec, float(e.min())))
+                if not gs:
+                    raise RuntimeError("No Ne sector produced eigenstates.")
+                e_gs_global = min(e for _, e in gs)
+                sectors = [sec for sec, e in gs
+                           if min(exct, sec['dim']) * numpy.exp(-self.beta * (e - e_gs_global))
+                           > sector_weight_threshold]
+                print("  thermal selection: {} of {} Ne sectors kept (weight > {:.1e})".format(
+                    len(sectors), len(all_sectors), sector_weight_threshold), flush=True)
+            else:
+                sectors = all_sectors
+
+            contributions = []
+            for sec in sectors:
+                Ne, dim = sec['Ne'], sec['dim']
+                exct_sec = min(exct, dim)
+                energies = run_ne_sector_eigenvalues(Ne, exct_sec)
+                if energies.size == 0:
+                    continue
+                warn_if_exct_truncates_thermal_trace(
+                    os.path.join('output', 'zvo_energy.dat'), self.beta, exct_sec, dim,
+                    weight_threshold=exct_weight_threshold)
+                E_min_sec = float(energies.min())
+                Z_sec = float(numpy.sum(numpy.exp(-self.beta * (energies - E_min_sec))))
+                p_common = (self.n_orb, T_list, exct_sec, eta, exec_path, "zvo", "./output",
+                            exct_sec, gf_mpi_prefix)
+                G_sec = calc_one_body_green_core_parallel(p_common, max_workers=n_outer, ne_only=Ne)
+                contributions.append((G_sec, E_min_sec, Z_sec))
+                print("  Ne sector Ne={:2d} dim={:5d} exct={:3d} E_min={:.6g} Z={:.3g}".format(
+                    Ne, dim, exct_sec, E_min_sec, Z_sec), flush=True)
+            if not contributions:
+                raise RuntimeError("No Ne sector produced eigenstates.")
+            E_min_global = min(c[1] for c in contributions)
+            weights = [c[2] * numpy.exp(-self.beta * (c[1] - E_min_global)) for c in contributions]
+            Z_global = sum(weights)
+            one_body_g = sum(w * c[0] for w, c in zip(weights, contributions)) / Z_global
+            print("\nFinish Gf calc ({} Ne sectors).".format(len(contributions)))
         else:
             print("\nComputing eigeneneries ...")
             with open('./stdout.log', 'w') as output_f:
@@ -624,9 +743,10 @@ class HPhiSolver(SolverBase):
         # if triqs_major_version == 1:
         #     set_tail(self._Gimp_iw)
 
-        if self.use_spin_orbit:
-            print("Sigma is not implemented for SOC")
-            raise NotImplementedError
+        # Sigma via Dyson Sigma = G0^-1 - Gimp^-1. The block structure below is generic in
+        # self.gf_struct / self.block_names: spin-orbit uses the single combined 'ud' block of
+        # size 2*n_orb (h0 and Gimp share the spin*n_orb+orbital ordering), so the same code path
+        # gives the spin-orbit self-energy.
 
         # Make H0 matrix
         h0_full = numpy.zeros((2, n_site, 2, n_site), dtype=complex)

--- a/src/dcore/impurity_solvers/hphi.py
+++ b/src/dcore/impurity_solvers/hphi.py
@@ -183,6 +183,47 @@ def warn_if_exct_truncates_thermal_trace(energy_file, beta, exct, exct_max, weig
         )
 
 
+def enumerate_particle_sectors(n_site):
+    """Enumerate the (Ne, 2Sz) sectors of a system of ``n_site`` sites (2*n_site spin-orbitals).
+
+    A sector is fixed in HPhi by ``Ncond = Ne`` and ``2Sz``; here ``n_up = (Ne + 2Sz)//2`` and
+    ``n_down = (Ne - 2Sz)//2``. The grand-canonical Hilbert space (dimension ``4**n_site``) is
+    the disjoint union of these sectors as a counting fact (every Fock state has a definite
+    (Ne, 2Sz)), which the unit tests check via ``sum(dim) == 4**n_site``.
+
+    **Validity of the (Ne, 2Sz) block decomposition for the spectrum.** Replacing one
+    grand-canonical run with per-sector canonical runs is correct only when the generated HPhi
+    Hamiltonian is block-diagonal in (Ne, 2Sz) -- i.e. it conserves BOTH the total electron
+    number Ne and 2Sz. That holds for density-density interactions plus number-conserving,
+    spin-diagonal one-body terms. It is BROKEN by anomalous/pairing terms (Ne not conserved) or
+    by spin-mixing one-body terms such as spin-orbit coupling (the transfer block can carry
+    ``s1 != s2``), which conserve Ne but not 2Sz. When only Ne is conserved one must sector by
+    Ne alone (no 2Sz constraint); when neither is conserved the canonical-by-sector path does
+    not apply and the grand-canonical run must be used. The caller (per-sector solver loop) is
+    responsible for checking these conservation laws on the actual Trans/InterAll before using
+    this enumeration. When the decomposition is valid, a sector's eigenvalues are exactly the
+    grand-canonical eigenvalues living in it, so the finite-T trace equals the sum of the
+    per-sector contributions (with a single global E_min and partition function Z).
+
+    Returns a list of dicts ``{'Ne', 'two_Sz', 'n_up', 'n_down', 'dim'}`` sorted by Ne then 2Sz.
+    """
+    from math import comb
+    if n_site < 0:
+        raise ValueError("n_site must be non-negative, got {}".format(n_site))
+    sectors = []
+    for n_up in range(n_site + 1):
+        for n_down in range(n_site + 1):
+            sectors.append({
+                'Ne': n_up + n_down,
+                'two_Sz': n_up - n_down,
+                'n_up': n_up,
+                'n_down': n_down,
+                'dim': comb(n_site, n_up) * comb(n_site, n_down),
+            })
+    sectors.sort(key=lambda s: (s['Ne'], s['two_Sz']))
+    return sectors
+
+
 def gf_parallel_layout(mpirun_command, np_total, n_procs_per_hphi):
     """
     Decide the two-level parallel layout for the Gf (one-body Green's function) step.
@@ -427,27 +468,89 @@ class HPhiSolver(SolverBase):
                 print(u.i1, u.s1, u.i2, u.s2, u.i3, u.s3, u.i4, u.s4, u.U.real, u.U.imag, file=f)
 
         # (2) Run a working horse
-        print("\nComputing eigeneneries ...")
-        with open('./stdout.log', 'w') as output_f:
-            launch_mpi_subprocesses(mpirun_command_eigen, [exec_path, '-e', 'namelist.def'], output_f)
+        # Sector-resolved (canonical) path is valid only when H conserves both Ne and 2Sz.
+        # Ne is always conserved (only c^dag c hopping + density interactions); 2Sz is broken
+        # by spin-orbit coupling (spin-mixing one-body terms), so guard on use_spin_orbit.
+        use_canonical = (os.environ.get("DCORE_HPHI_CANONICAL_SECTORS", "0") == "1"
+                         and not self.use_spin_orbit)
 
-        # Warn if too few eigenstates were computed to span the thermally relevant
-        # multiplet (e.g. a degenerate ground state with the default exct=1).
-        warn_if_exct_truncates_thermal_trace(
-            os.path.join('output', 'zvo_energy.dat'), self.beta, exct, exct_max,
-            weight_threshold=exct_weight_threshold)
+        if use_canonical:
+            # H is block-diagonal in (Ne, 2Sz), so the grand-canonical finite-T trace equals the
+            # weighted sum of per-sector canonical contributions. Each sector spans a much smaller
+            # Hilbert space than the full 4**n_site grand-canonical space, which is where the
+            # dominant Green's-function (BiCG) cost shrinks. Each sector run returns its own
+            # finite-T-normalized Gf G_s and we recombine exactly with
+            #   G = sum_s w_s G_s / sum_s w_s,  w_s = Z_s * exp(-beta (Emin_s - Emin_global)),
+            # which reproduces the single global Boltzmann sum.
+            print("\nComputing eigenenergies + Gf per (Ne, 2Sz) sector ...")
+            canonical_calcmod = calcmod_def.replace("CalcModel   3", "CalcModel   0")
+            contributions = []  # list of (G_sector, E_min_sector, Z_sector)
+            T_list = [1. / self.beta]
+            eta = 1e-4
+            for sec in enumerate_particle_sectors(n_site):
+                Ne, two_Sz, dim = sec['Ne'], sec['two_Sz'], sec['dim']
+                exct_sec = min(exct, dim)
+                if exct_sec < 1:
+                    continue
+                sector_modpara = modpara_def.format(n_site, exct_sec, self.n_iw, omega_max, omega_min)
+                # the convergence target cannot exceed the number of states in this sector
+                sector_modpara = sector_modpara.replace("LanczosTarget  2",
+                                                        "LanczosTarget  {}".format(min(2, exct_sec)))
+                sector_modpara += "Ncond          {}\n2Sz            {}\n".format(Ne, two_Sz)
+                with open('./modpara.def', 'w') as f:
+                    f.write(sector_modpara)
+                with open('./calcmod.def', 'w') as f:
+                    f.write(canonical_calcmod)
+                with open('./stdout.log', 'w') as output_f:
+                    launch_mpi_subprocesses(mpirun_command_eigen, [exec_path, '-e', 'namelist.def'], output_f)
+                energies = read_eigenenergies(os.path.join('output', 'zvo_energy.dat'))
+                if energies.size == 0:
+                    continue
+                # Same thermal-truncation guard as the grand-canonical path, per sector: if
+                # exct_sec < dim and the highest retained state still carries weight, this
+                # sector's trace (and Z_sec) is truncated, which would bias the recombined Gf.
+                warn_if_exct_truncates_thermal_trace(
+                    os.path.join('output', 'zvo_energy.dat'), self.beta, exct_sec, dim,
+                    weight_threshold=exct_weight_threshold)
+                E_min_sec = float(energies.min())
+                Z_sec = float(numpy.sum(numpy.exp(-self.beta * (energies - E_min_sec))))
+                p_common = (self.n_orb, T_list, exct_sec, eta, exec_path, "zvo", "./output",
+                            exct_sec, gf_mpi_prefix)
+                G_sec = calc_one_body_green_core_parallel(
+                    p_common, max_workers=n_outer,
+                    sector_occupancy=(sec['n_up'], sec['n_down'], n_site))
+                contributions.append((G_sec, E_min_sec, Z_sec))
+                print("  sector Ne={:2d} 2Sz={:+d} dim={:5d} exct={:3d} E_min={:.6g} Z={:.3g}".format(
+                    Ne, two_Sz, dim, exct_sec, E_min_sec, Z_sec), flush=True)
+            if not contributions:
+                raise RuntimeError("No (Ne, 2Sz) sector produced eigenstates.")
+            E_min_global = min(c[1] for c in contributions)
+            weights = [c[2] * numpy.exp(-self.beta * (c[1] - E_min_global)) for c in contributions]
+            Z_global = sum(weights)
+            one_body_g = sum(w * c[0] for w, c in zip(weights, contributions)) / Z_global
+            print("\nFinish Gf calc ({} sectors).".format(len(contributions)))
+        else:
+            print("\nComputing eigeneneries ...")
+            with open('./stdout.log', 'w') as output_f:
+                launch_mpi_subprocesses(mpirun_command_eigen, [exec_path, '-e', 'namelist.def'], output_f)
 
-        print("\nComputing Gf ...")
-        if n_inner > 1:
-            print(f"  Gf parallel layout: {n_outer} concurrent HPhi run(s) x {n_inner} MPI rank(s) each")
-        header = "zvo"
-        T_list = [1./self.beta]
-        eta = 1e-4
-        output_dir = "./output"
-        p_common = (self.n_orb, T_list, exct, eta, exec_path, header, output_dir, exct, gf_mpi_prefix)
-        one_body_g = calc_one_body_green_core_parallel(p_common, max_workers=n_outer)
+            # Warn if too few eigenstates were computed to span the thermally relevant
+            # multiplet (e.g. a degenerate ground state with the default exct=1).
+            warn_if_exct_truncates_thermal_trace(
+                os.path.join('output', 'zvo_energy.dat'), self.beta, exct, exct_max,
+                weight_threshold=exct_weight_threshold)
 
-        print("\nFinish Gf calc.")
+            print("\nComputing Gf ...")
+            if n_inner > 1:
+                print(f"  Gf parallel layout: {n_outer} concurrent HPhi run(s) x {n_inner} MPI rank(s) each")
+            header = "zvo"
+            T_list = [1./self.beta]
+            eta = 1e-4
+            output_dir = "./output"
+            p_common = (self.n_orb, T_list, exct, eta, exec_path, header, output_dir, exct, gf_mpi_prefix)
+            one_body_g = calc_one_body_green_core_parallel(p_common, max_workers=n_outer)
+
+            print("\nFinish Gf calc.")
 
         # print(one_body_g.shape)
         assert isinstance(one_body_g, numpy.ndarray)

--- a/src/dcore/impurity_solvers/hphi.py
+++ b/src/dcore/impurity_solvers/hphi.py
@@ -306,10 +306,6 @@ class HPhiSolver(SolverBase):
         p_common = (self.n_orb, T_list, exct, eta, exec_path, header, output_dir, exct)
         one_body_g = calc_one_body_green_core_parallel(p_common, max_workers=np)
 
-        # calcspectrum = CalcSpectrum(T_list, exct=exct, eta=eta, path_to_HPhi=exec_path, header=header)
-        # energy_list = calcspectrum.get_energies()
-        # one_body_g = calcspectrum.get_one_body_green(n_site=self.n_orb, exct_cut=exct)
-
         print("\nFinish Gf calc.")
 
         # print(one_body_g.shape)

--- a/src/dcore/impurity_solvers/hphi.py
+++ b/src/dcore/impurity_solvers/hphi.py
@@ -153,24 +153,32 @@ def warn_if_exct_truncates_thermal_trace(energy_file, beta, exct, exct_max, weig
     e_last = energies.max()
     # eigenenergies are printed to ~1e-9 precision, so a loose tol identifies degeneracy
     degeneracy = int(numpy.count_nonzero(numpy.abs(energies - e0) < 1e-6))
+
+    # All omitted states have energy >= e_last (we kept the lowest exct states),
+    # so w_last = exp(-beta*(e_last - e0)) is an UPPER BOUND on the Boltzmann
+    # weight of each omitted state. If w_last <= threshold the omitted tail is
+    # provably negligible; otherwise truncation cannot be ruled out (we cannot
+    # see whether the next state sits just above e_last or far above it), so we
+    # warn conservatively.
     w_last = math.exp(-beta * (e_last - e0))
 
     if w_last > weight_threshold:
         if degeneracy >= exct:
-            deg_msg = (f"  All {exct} computed states are degenerate with the ground "
-                       f"state, so the ground multiplet itself is not fully covered.\n")
+            deg_msg = (f"  All {exct} computed states are degenerate with the ground state, "
+                       f"so the cutoff falls inside the ground multiplet.\n")
         else:
             deg_msg = f"  The ground state is {degeneracy}-fold degenerate.\n"
         print(
             "\n*** WARNING (HPhi solver): 'exct' may be too small ***\n"
             f"  exct = {exct} eigenstates were computed (full space = {exct_max}).\n"
             + deg_msg +
-            f"  The highest computed state still has Boltzmann weight {w_last:.2e} "
-            f"(> {weight_threshold:.0e}) at T = {1.0 / beta:.4g},\n"
-            "  so thermally-relevant states above the cutoff are missing from the\n"
-            "  finite-T trace. This can break orbital symmetry and yield a wrong\n"
-            "  (e.g. spurious off-diagonal) self-energy.\n"
-            "  => Increase 'exct' until this warning disappears.\n",
+            f"  The highest computed state has Boltzmann weight {w_last:.2e} at "
+            f"T = {1.0 / beta:.4g}; this is an upper bound on the weight of every\n"
+            f"  omitted (higher) state, and it exceeds {weight_threshold:.0e}. A "
+            "thermally-relevant state above the cutoff therefore cannot be ruled\n"
+            "  out: the finite-T trace may be truncated, which can break orbital "
+            "symmetry and yield a wrong (e.g. spurious off-diagonal) self-energy.\n"
+            "  => Increase 'exct'; if the result does not change, it was already converged.\n",
             file=sys.stderr,
         )
 

--- a/src/dcore/impurity_solvers/hphi.py
+++ b/src/dcore/impurity_solvers/hphi.py
@@ -471,8 +471,15 @@ class HPhiSolver(SolverBase):
         # Sector-resolved (canonical) path is valid only when H conserves both Ne and 2Sz.
         # Ne is always conserved (only c^dag c hopping + density interactions); 2Sz is broken
         # by spin-orbit coupling (spin-mixing one-body terms), so guard on use_spin_orbit.
-        use_canonical = (os.environ.get("DCORE_HPHI_CANONICAL_SECTORS", "0") == "1"
+        # The Stage-3 direct bra/ket Green's function (DCORE_HPHI_BRAKET=1) is built on the
+        # per-(Ne, 2Sz) sector decomposition, so it implies the canonical path. Both require a
+        # 2Sz-conserving (no spin-orbit) Hamiltonian.
+        use_braket = os.environ.get("DCORE_HPHI_BRAKET", "0") == "1"
+        use_canonical = ((os.environ.get("DCORE_HPHI_CANONICAL_SECTORS", "0") == "1" or use_braket)
                          and not self.use_spin_orbit)
+        if use_braket and self.use_spin_orbit:
+            raise RuntimeError("DCORE_HPHI_BRAKET=1 is not supported with spin-orbit coupling "
+                               "(2Sz must be conserved); use the default solver.")
 
         if use_canonical:
             # H is block-diagonal in (Ne, 2Sz), so the grand-canonical finite-T trace equals the

--- a/src/dcore/impurity_solvers/hphi.py
+++ b/src/dcore/impurity_solvers/hphi.py
@@ -111,6 +111,70 @@ NInterAll      {0}
 """
 
 
+def read_eigenenergies(energy_file):
+    """Read the eigenenergies (one per computed state) from an HPhi zvo_energy.dat file."""
+    energies = []
+    with open(energy_file) as f:
+        for line in f:
+            tokens = line.split()
+            if len(tokens) >= 2 and tokens[0] == 'Energy':
+                energies.append(float(tokens[1]))
+    return numpy.array(energies)
+
+
+def warn_if_exct_truncates_thermal_trace(energy_file, beta, exct, exct_max, weight_threshold=1e-3):
+    """
+    Warn if too few eigenstates were computed to span the thermally relevant
+    multiplet at temperature T = 1/beta.
+
+    HPhi builds the finite-T Green's function from the lowest ``exct`` eigenstates,
+    weighting state n by the Boltzmann factor exp(-beta*(E_n - E_0)).  If the
+    highest computed state still carries a non-negligible weight, states just
+    above the cutoff are missing from the thermal trace.  This typically happens
+    when the ground state is degenerate (common in multi-orbital models) and the
+    default ``exct = 1`` keeps only one member of the multiplet -- silently
+    breaking orbital symmetry and producing a wrong (e.g. spurious off-diagonal)
+    self-energy.
+
+    A warning is printed (it does not abort the solver).  It never fires when the
+    full Hilbert space is already covered (exct == exct_max).
+    """
+    if exct >= exct_max:
+        return  # full Hilbert space is covered; nothing is truncated
+
+    try:
+        energies = read_eigenenergies(energy_file)
+    except (OSError, ValueError):
+        return  # tolerate a missing/odd energy file rather than aborting the solver
+    if energies.size == 0:
+        return
+
+    e0 = energies.min()
+    e_last = energies.max()
+    # eigenenergies are printed to ~1e-9 precision, so a loose tol identifies degeneracy
+    degeneracy = int(numpy.count_nonzero(numpy.abs(energies - e0) < 1e-6))
+    w_last = math.exp(-beta * (e_last - e0))
+
+    if w_last > weight_threshold:
+        if degeneracy >= exct:
+            deg_msg = (f"  All {exct} computed states are degenerate with the ground "
+                       f"state, so the ground multiplet itself is not fully covered.\n")
+        else:
+            deg_msg = f"  The ground state is {degeneracy}-fold degenerate.\n"
+        print(
+            "\n*** WARNING (HPhi solver): 'exct' may be too small ***\n"
+            f"  exct = {exct} eigenstates were computed (full space = {exct_max}).\n"
+            + deg_msg +
+            f"  The highest computed state still has Boltzmann weight {w_last:.2e} "
+            f"(> {weight_threshold:.0e}) at T = {1.0 / beta:.4g},\n"
+            "  so thermally-relevant states above the cutoff are missing from the\n"
+            "  finite-T trace. This can break orbital symmetry and yield a wrong\n"
+            "  (e.g. spurious off-diagonal) self-energy.\n"
+            "  => Increase 'exct' until this warning disappears.\n",
+            file=sys.stderr,
+        )
+
+
 class HPhiSolver(SolverBase):
 
     def __init__(self, beta, gf_struct, u_mat, n_iw=1025):
@@ -167,6 +231,8 @@ class HPhiSolver(SolverBase):
         # bath fitting
         n_bath = params_kw.get('n_bath', 0)  # 0 for Hubbard-I approximation
         exct = params_kw.get('exct', 1)  # number of states to be computed
+        # Boltzmann-weight threshold above which an under-sized exct triggers a warning
+        exct_weight_threshold = params_kw.get('exct_weight_threshold', 1e-3)
 
         fit_params = {}
         for key in ['fit_gtol',]:
@@ -297,6 +363,12 @@ class HPhiSolver(SolverBase):
         print("\nComputing eigeneneries ...")
         with open('./stdout.log', 'w') as output_f:
             launch_mpi_subprocesses(mpirun_command_power4, [exec_path, '-e', 'namelist.def'], output_f)
+
+        # Warn if too few eigenstates were computed to span the thermally relevant
+        # multiplet (e.g. a degenerate ground state with the default exct=1).
+        warn_if_exct_truncates_thermal_trace(
+            os.path.join('output', 'zvo_energy.dat'), self.beta, exct, exct_max,
+            weight_threshold=exct_weight_threshold)
 
         print("\nComputing Gf ...")
         header = "zvo"

--- a/src/dcore/impurity_solvers/hphi.py
+++ b/src/dcore/impurity_solvers/hphi.py
@@ -175,6 +175,48 @@ def warn_if_exct_truncates_thermal_trace(energy_file, beta, exct, exct_max, weig
         )
 
 
+def gf_parallel_layout(mpirun_command, np_total, n_procs_per_hphi):
+    """
+    Decide the two-level parallel layout for the Gf (one-body Green's function) step.
+
+    The Gf step runs one HPhi calculation per (excitation) task; the tasks are
+    independent, so they can be spread over ``n_outer`` concurrent runs, each of
+    which may itself use ``n_inner`` MPI ranks.
+
+    Parameters
+    ----------
+    mpirun_command : str
+        The MPI launcher, e.g. ``"mpirun -np 16"`` (last token = number of ranks).
+    np_total : int or None
+        Total number of processes (``None`` if it could not be parsed).
+    n_procs_per_hphi : int
+        Requested MPI ranks per HPhi run (``n_inner``). ``1`` keeps the previous
+        behaviour (serial HPhi, ``np_total`` concurrent runs).
+
+    Returns
+    -------
+    (n_inner, n_outer, gf_mpi_prefix)
+        ``n_inner`` is clamped to a power of four not exceeding ``np_total``;
+        ``n_outer = np_total // n_inner`` is the ProcessPool size; ``gf_mpi_prefix``
+        is prepended to each HPhi command (``""`` when running serially).
+    """
+    if np_total is None:
+        return 1, None, ""
+    n_inner = max(1, min(int(n_procs_per_hphi), np_total))
+    if not math.log(n_inner, 4).is_integer():  # HPhi requires a power of four
+        n_inner = 4 ** int(math.log(n_inner, 4))
+        print(f"Warning: n_procs_per_hphi must be a power of four in HPhi. "
+              f"It is set to {n_inner} for the Gf calculation.", file=sys.stderr)
+    n_outer = max(1, np_total // n_inner)
+    if n_inner == 1:
+        gf_mpi_prefix = ""  # serial HPhi (no mpirun), as before
+    else:
+        cmds = shlex.split(mpirun_command)
+        cmds[-1] = str(n_inner)
+        gf_mpi_prefix = " ".join(cmds)
+    return n_inner, n_outer, gf_mpi_prefix
+
+
 class HPhiSolver(SolverBase):
 
     def __init__(self, beta, gf_struct, u_mat, n_iw=1025):
@@ -220,6 +262,13 @@ class HPhiSolver(SolverBase):
                 print(f"Warning: np must be a power of 4 in HPhi. np is set to {np_new} in eigenenergies calculations. Note that np={np} is used for Gf calculations.", file=sys.stderr)
                 commands[-1] = str(np_new)
                 mpirun_command_power4 = " ".join(commands)
+
+        # Two-level parallelism for the Gf step: run n_outer pairs concurrently,
+        # each HPhi using n_inner MPI ranks, with n_inner * n_outer ~ np.
+        #   n_procs_per_hphi (= n_inner): MPI ranks per HPhi run (1 = serial, the
+        #   default and the previous behavior). Must be a power of four (HPhi).
+        n_inner, n_outer, gf_mpi_prefix = gf_parallel_layout(
+            mpirun_command, np, params_kw.get('n_procs_per_hphi', 1))
 
         # Matsubara frequencies omega_n = (2*n+1)*pi*T
         omega_min = numpy.pi / self.beta  # n=0
@@ -371,12 +420,14 @@ class HPhiSolver(SolverBase):
             weight_threshold=exct_weight_threshold)
 
         print("\nComputing Gf ...")
+        if n_inner > 1:
+            print(f"  Gf parallel layout: {n_outer} concurrent HPhi run(s) x {n_inner} MPI rank(s) each")
         header = "zvo"
         T_list = [1./self.beta]
         eta = 1e-4
         output_dir = "./output"
-        p_common = (self.n_orb, T_list, exct, eta, exec_path, header, output_dir, exct)
-        one_body_g = calc_one_body_green_core_parallel(p_common, max_workers=np)
+        p_common = (self.n_orb, T_list, exct, eta, exec_path, header, output_dir, exct, gf_mpi_prefix)
+        one_body_g = calc_one_body_green_core_parallel(p_common, max_workers=n_outer)
 
         print("\nFinish Gf calc.")
 

--- a/src/dcore/impurity_solvers/hphi.py
+++ b/src/dcore/impurity_solvers/hphi.py
@@ -248,6 +248,27 @@ def enumerate_ne_sectors(n_site):
     return [{'Ne': ne, 'dim': comb(n_so, ne)} for ne in range(n_so + 1)]
 
 
+def ne_initial_sectors(n_site, exct):
+    """Split the Ne-only sectors into the ones the spin-orbit (HubbardNConserved) bra/ket route
+    can actually run as thermally occupied INITIAL sectors, and the boundary sectors it must drop.
+
+    HPhi cannot run the vacuum sector (Ne = 0; it rejects Ncond = 0) nor, due to a
+    HubbardNConserved Hilbert-construction (sz()) edge case, the fully occupied sector
+    (Ne = 2*n_site). Both are single states and are excluded as INITIAL sectors; interior sectors
+    still reach those boundary EXCITED spaces through their Ne+-1 transitions. Dropping the two
+    boundary initial sectors makes the finite-T trace exact only when neither boundary state
+    carries appreciable Boltzmann weight (i.e. the impurity is not near-empty or near-full).
+
+    Returns ``(kept, dropped)`` where ``kept`` is the list of runnable sector dicts
+    (``{'Ne', 'dim'}``) and ``dropped`` is the sorted list of omitted Ne values.
+    """
+    ne_lo, ne_hi = 1, 2 * n_site - 1
+    runnable = [s for s in enumerate_ne_sectors(n_site) if min(exct, s['dim']) >= 1]
+    kept = [s for s in runnable if ne_lo <= s['Ne'] <= ne_hi]
+    dropped = sorted({s['Ne'] for s in runnable if not (ne_lo <= s['Ne'] <= ne_hi)})
+    return kept, dropped
+
+
 def gf_parallel_layout(mpirun_command, np_total, n_procs_per_hphi):
     """
     Decide the two-level parallel layout for the Gf (one-body Green's function) step.
@@ -641,17 +662,13 @@ class HPhiSolver(SolverBase):
             # extreme chemical-potential / crystal-field regimes, where the result would be biased.
             # It is therefore dropped EXPLICITLY (loud warning, not silent); an exact treatment of
             # the two dim-1 edges is a known follow-up.
-            ne_lo, ne_hi = 1, 2 * n_site - 1
-            dropped = sorted({s['Ne'] for s in enumerate_ne_sectors(n_site)
-                              if min(exct, s['dim']) >= 1 and not (ne_lo <= s['Ne'] <= ne_hi)})
+            all_sectors, dropped = ne_initial_sectors(n_site, exct)
             if dropped:
                 print("Warning: the spin-orbit (HubbardNConserved) bra/ket route cannot run the "
                       "boundary Ne sectors {}; they are dropped. The finite-T trace is exact only "
                       "if these near-empty/near-full states are thermally negligible (typical "
                       "partial filling) -- verify the filling is not extreme.".format(dropped),
                       file=sys.stderr)
-            all_sectors = [s for s in enumerate_ne_sectors(n_site)
-                           if min(exct, s['dim']) >= 1 and ne_lo <= s['Ne'] <= ne_hi]
             if sector_weight_threshold > 0.0:
                 gs = []
                 for sec in all_sectors:

--- a/src/dcore/impurity_solvers/hphi.py
+++ b/src/dcore/impurity_solvers/hphi.py
@@ -484,18 +484,23 @@ class HPhiSolver(SolverBase):
             # which reproduces the single global Boltzmann sum.
             print("\nComputing eigenenergies + Gf per (Ne, 2Sz) sector ...")
             canonical_calcmod = calcmod_def.replace("CalcModel   3", "CalcModel   0")
-            contributions = []  # list of (G_sector, E_min_sector, Z_sector)
             T_list = [1. / self.beta]
             eta = 1e-4
-            for sec in enumerate_particle_sectors(n_site):
-                Ne, two_Sz, dim = sec['Ne'], sec['two_Sz'], sec['dim']
-                exct_sec = min(exct, dim)
-                if exct_sec < 1:
-                    continue
-                sector_modpara = modpara_def.format(n_site, exct_sec, self.n_iw, omega_max, omega_min)
+            # Drop sectors whose (bounded) thermal contribution is below this, relative to the
+            # global ground state: they contribute negligibly to the finite-T trace.
+            # 0 disables the selection (compute every sector -- exact but slower).
+            sector_weight_threshold = params_kw.get('canonical_sector_weight_threshold', 1e-8)
+            if not (0.0 <= sector_weight_threshold < 1.0):
+                raise ValueError("canonical_sector_weight_threshold must be in [0, 1), got {}"
+                                 .format(sector_weight_threshold))
+
+            def run_sector_eigenvalues(Ne, two_Sz, exct_use):
+                """Write the canonical (Ncond, 2Sz) modpara/calcmod and run the eigenvalue step;
+                return the eigenenergies (empty array if the sector produced nothing)."""
+                sector_modpara = modpara_def.format(n_site, exct_use, self.n_iw, omega_max, omega_min)
                 # the convergence target cannot exceed the number of states in this sector
                 sector_modpara = sector_modpara.replace("LanczosTarget  2",
-                                                        "LanczosTarget  {}".format(min(2, exct_sec)))
+                                                        "LanczosTarget  {}".format(min(2, exct_use)))
                 sector_modpara += "Ncond          {}\n2Sz            {}\n".format(Ne, two_Sz)
                 with open('./modpara.def', 'w') as f:
                     f.write(sector_modpara)
@@ -503,7 +508,41 @@ class HPhiSolver(SolverBase):
                     f.write(canonical_calcmod)
                 with open('./stdout.log', 'w') as output_f:
                     launch_mpi_subprocesses(mpirun_command_eigen, [exec_path, '-e', 'namelist.def'], output_f)
-                energies = read_eigenenergies(os.path.join('output', 'zvo_energy.dat'))
+                return read_eigenenergies(os.path.join('output', 'zvo_energy.dat'))
+
+            all_sectors = [s for s in enumerate_particle_sectors(n_site) if min(exct, s['dim']) >= 1]
+
+            # Phase-2 thermal selection: a cheap ground-state-only pre-pass per sector picks the
+            # thermally relevant (Ne, 2Sz) sectors, so the dominant per-sector Gf step runs only
+            # for those. The spectrum reaches the (Ne+-1) excited sectors internally, so only the
+            # thermally OCCUPIED sectors need an eigenvalue/Gf run here.
+            if sector_weight_threshold > 0.0:
+                gs = []
+                for sec in all_sectors:
+                    e = run_sector_eigenvalues(sec['Ne'], sec['two_Sz'], 1)
+                    if e.size > 0:
+                        gs.append((sec, float(e.min())))
+                if not gs:
+                    raise RuntimeError("No (Ne, 2Sz) sector produced eigenstates.")
+                e_gs_global = min(e for _, e in gs)
+                # A sector's contribution to the un-normalized trace is
+                # Z_sec * exp(-beta(Egs_sec - Egs_global)) with Z_sec = sum_i exp(-beta(E_i-Egs_sec))
+                # <= the number of states summed (<= min(exct, dim)). Bounding Z_sec by that count
+                # (rather than filtering on the ground-state weight alone) makes the cut safe even
+                # for sectors whose many low-lying / nearly degenerate states give a large Z_sec.
+                sectors = [sec for sec, e in gs
+                           if min(exct, sec['dim']) * numpy.exp(-self.beta * (e - e_gs_global))
+                           > sector_weight_threshold]
+                print("  thermal selection: {} of {} sectors kept (weight > {:.1e})".format(
+                    len(sectors), len(all_sectors), sector_weight_threshold), flush=True)
+            else:
+                sectors = all_sectors
+
+            contributions = []  # list of (G_sector, E_min_sector, Z_sector)
+            for sec in sectors:
+                Ne, two_Sz, dim = sec['Ne'], sec['two_Sz'], sec['dim']
+                exct_sec = min(exct, dim)
+                energies = run_sector_eigenvalues(Ne, two_Sz, exct_sec)
                 if energies.size == 0:
                     continue
                 # Same thermal-truncation guard as the grand-canonical path, per sector: if

--- a/src/dcore/impurity_solvers/hphi.py
+++ b/src/dcore/impurity_solvers/hphi.py
@@ -203,26 +203,40 @@ def gf_parallel_layout(mpirun_command, np_total, n_procs_per_hphi):
 
     Returns
     -------
-    (n_inner, n_outer, gf_mpi_prefix)
+    (n_inner, n_outer, hphi_mpi_command, gf_mpi_prefix)
         ``n_inner`` is clamped to a power of four not exceeding ``np_total``;
-        ``n_outer = np_total // n_inner`` is the ProcessPool size; ``gf_mpi_prefix``
-        is prepended to each HPhi command (``""`` when running serially).
+        ``n_outer = np_total // n_inner`` is the ProcessPool size.
+        ``hphi_mpi_command`` is the launcher for a *single* HPhi run with
+        ``n_inner`` ranks -- it is used for BOTH the eigenvalue step and each
+        Green's-function run. They must use the same rank count because the
+        eigenvectors are written MPI-distributed (one file per rank) by the
+        eigenvalue step and read back by the Green's-function step.
+        ``gf_mpi_prefix`` is that same launcher prepended to each Gf shell
+        command (``""`` when ``n_inner == 1``, i.e. a bare/serial HPhi run).
     """
     if np_total is None:
-        return 1, None, ""
+        # The rank count is not the launcher's last token, so we cannot rewrite
+        # it to split the Gf step. Preserve correctness instead of speed: drive
+        # BOTH phases with the *same* launcher (so the eigenvector rank counts
+        # match) and do not run Gf runs concurrently (n_outer = 1), since we
+        # cannot tell how many ranks each run would take.
+        print("Note (HPhi solver): could not parse the process count from the MPI "
+              "command; the Gf step is not parallelized (put the rank count as the "
+              "last token of [mpi] command to enable it).", file=sys.stderr)
+        return 1, 1, mpirun_command, mpirun_command
     n_inner = max(1, min(int(n_procs_per_hphi), np_total))
     if not math.log(n_inner, 4).is_integer():  # HPhi requires a power of four
         n_inner = 4 ** int(math.log(n_inner, 4))
         print(f"Warning: n_procs_per_hphi must be a power of four in HPhi. "
-              f"It is set to {n_inner} for the Gf calculation.", file=sys.stderr)
+              f"It is set to {n_inner} (ranks per HPhi run).", file=sys.stderr)
     n_outer = max(1, np_total // n_inner)
-    if n_inner == 1:
-        gf_mpi_prefix = ""  # serial HPhi (no mpirun), as before
-    else:
-        cmds = shlex.split(mpirun_command)
-        cmds[-1] = str(n_inner)
-        gf_mpi_prefix = " ".join(cmds)
-    return n_inner, n_outer, gf_mpi_prefix
+    cmds = shlex.split(mpirun_command)
+    cmds[-1] = str(n_inner)
+    hphi_mpi_command = " ".join(cmds)
+    # The Gf runs may go bare when single-rank, but the eigenvalue step always
+    # uses the launcher so its rank count matches what the Gf step expects.
+    gf_mpi_prefix = "" if n_inner == 1 else hphi_mpi_command
+    return n_inner, n_outer, hphi_mpi_command, gf_mpi_prefix
 
 
 class HPhiSolver(SolverBase):
@@ -256,26 +270,22 @@ class HPhiSolver(SolverBase):
 
         exec_path = expand_path(params_kw['exec_path'])
 
-        # The number of process (np) must be 4^m in HPhi
-        mpirun_command_power4 = mpirun_command
+        # Parse the total number of processes from the launcher's last token.
         commands = shlex.split(mpirun_command)
         try:
             np = int(commands[-1])
         except ValueError:
             np = None
             print("A check of np is skipped.")
-        else:
-            if not math.log(np, 4).is_integer():  # check if np = 4^m
-                np_new = 4**int(math.log(np, 4))
-                print(f"Warning: np must be a power of 4 in HPhi. np is set to {np_new} in eigenenergies calculations. Note that np={np} is used for Gf calculations.", file=sys.stderr)
-                commands[-1] = str(np_new)
-                mpirun_command_power4 = " ".join(commands)
 
-        # Two-level parallelism for the Gf step: run n_outer pairs concurrently,
-        # each HPhi using n_inner MPI ranks, with n_inner * n_outer ~ np.
-        #   n_procs_per_hphi (= n_inner): MPI ranks per HPhi run (1 = serial, the
-        #   default and the previous behavior). Must be a power of four (HPhi).
-        n_inner, n_outer, gf_mpi_prefix = gf_parallel_layout(
+        # Two-level parallelism for the Gf step. CRUCIAL: the eigenvalue step and
+        # every Green's-function run must use the SAME number of MPI ranks
+        # (n_inner), because the eigenvalue step writes the eigenvectors
+        # MPI-distributed (one file per rank) and the Gf step reads them back -- a
+        # rank-count mismatch makes HPhi stop while inputting the eigenvector.
+        #   n_procs_per_hphi (= n_inner): MPI ranks per HPhi run (power of four;
+        #   1 = serial, the default). n_outer = np // n_inner runs run concurrently.
+        n_inner, n_outer, mpirun_command_eigen, gf_mpi_prefix = gf_parallel_layout(
             mpirun_command, np, params_kw.get('n_procs_per_hphi', 1))
 
         # Matsubara frequencies omega_n = (2*n+1)*pi*T
@@ -419,7 +429,7 @@ class HPhiSolver(SolverBase):
         # (2) Run a working horse
         print("\nComputing eigeneneries ...")
         with open('./stdout.log', 'w') as output_f:
-            launch_mpi_subprocesses(mpirun_command_power4, [exec_path, '-e', 'namelist.def'], output_f)
+            launch_mpi_subprocesses(mpirun_command_eigen, [exec_path, '-e', 'namelist.def'], output_f)
 
         # Warn if too few eigenstates were computed to span the thermally relevant
         # multiplet (e.g. a degenerate ground state with the default exct=1).

--- a/src/dcore/impurity_solvers/hphi_spectrum.py
+++ b/src/dcore/impurity_solvers/hphi_spectrum.py
@@ -122,42 +122,65 @@ class CalcSpectrumCore:
         # MPI launcher for each HPhi run of the Gf step (e.g. "mpirun -np 4");
         # empty string runs HPhi serially (one rank, no mpirun).
         self.mpi_prefix = mpi_prefix
+        # When enabled, HPhi loops over the exct_cut eigenstates internally
+        # (SpectrumLoopExct in modpara): one launch per excitation operator instead
+        # of one per (eigenstate x operator), eliminating the per-state process-startup
+        # overhead. Requires an HPhi build with the SpectrumLoopExct feature. The
+        # per-idx path (default) stays as the validated fallback / reference.
+        self.internal_loop = os.environ.get("DCORE_HPHI_INTERNAL_LOOP", "0") == "1"
 
     def Make_Spectrum_Input(self, calc_dir="./", spectrum_type="single"):
 
         rel_path_org = os.path.relpath(self.parent_dir, calc_dir)
-        for idx in range(self.exct):
+        rel_path = os.path.relpath(os.path.join(self.parent_dir, "output"), calc_dir)
+        spvec_base = os.path.join("../", rel_path, self.header) + "_eigenvec"
+
+        def _write_calcmod():
             with open(os.path.join(self.parent_dir, "calcmod.def")) as f:
                 lines = f.readlines()
             with open(os.path.join(calc_dir, "calcmod_ex.def"), "w") as fex:
                 for line in lines:
-                   words = line.split()
-                   if words[0] == "CalcSpec" or words[0] == "OutputExVec" or words[0] == "OutputEigenVec":
-                    continue
-                   fex.write(line)
+                    words = line.split()
+                    if words[0] in ("CalcSpec", "OutputExVec", "OutputEigenVec"):
+                        continue
+                    fex.write(line)
                 fex.write("CalcSpec    1\n")
+
+        def _write_namelist(fname, spectrum_vec):
             with open(os.path.join(self.parent_dir, "namelist.def")) as f:
                 lines = f.readlines()
-            with open(os.path.join(calc_dir, "namelist_ex_{}.def".format(idx)), "w") as fex:
+            with open(os.path.join(calc_dir, fname), "w") as fex:
                 for line in lines:
                     words = line.split()
                     if len(words) == 0:
                         continue
-                    if words[0] in ["CalcMod", "SpectrumVec", "ModPara"]:
-                        continue
-                    if words[0] == "SingleExcitation":
-                        continue
-                    if words[0] == "PairExcitation":
+                    if words[0] in ["CalcMod", "SpectrumVec", "ModPara",
+                                    "SingleExcitation", "PairExcitation"]:
                         continue
                     fex.write("{} {}\n".format(words[0], os.path.join(rel_path_org, words[1])))
                 fex.write("ModPara modpara_ex.def\n")
                 fex.write("CalcMod calcmod_ex.def\n")
-                rel_path = os.path.relpath(os.path.join(self.parent_dir, "output"), calc_dir)
-                fex.write("SpectrumVec    {}_eigenvec_{}\n".format(os.path.join("../", rel_path, self.header), idx))
+                fex.write("SpectrumVec    {}\n".format(spectrum_vec))
                 if spectrum_type == "single":
                     fex.write("SingleExcitation single_ex.def\n")
                 elif spectrum_type == "pair":
                     fex.write("PairExcitation pair_ex.def\n")
+
+        _write_calcmod()
+        if self.internal_loop:
+            # One launch: HPhi loops eigenstates internally and appends
+            # _<idx>_rank_<r>.dat to this common SpectrumVec base per eigenstate.
+            _write_namelist("namelist_ex.def", spvec_base)
+            # HPhi (loop mode) reads E_idx from <calc_dir>/output/<header>_energy.dat
+            # (childfopenMPI prepends 'output/'); stage it from the eigenvalue run.
+            import shutil
+            os.makedirs(os.path.join(calc_dir, "output"), exist_ok=True)
+            shutil.copy(os.path.join(self.parent_dir, self.output_dir, "{}_energy.dat".format(self.header)),
+                        os.path.join(calc_dir, "output", "{}_energy.dat".format(self.header)))
+        else:
+            for idx in range(self.exct):
+                _write_namelist("namelist_ex_{}.def".format(idx),
+                                "{}_{}".format(spvec_base, idx))
 
         with open(os.path.join(self.parent_dir,"modpara.def"), "r") as fr:
             lines = fr.readlines()
@@ -239,7 +262,12 @@ class CalcSpectrumCore:
             for line in lines[8:]:
                 words = line.split()
                 dict_mod[words[0]] = words[1:]
-            dict_mod["OmegaOrg"] = [self.energy_list[exct], 0]
+            if self.internal_loop:
+                # 'exct' is the loop COUNT (= exct_cut); HPhi reads each E_idx from
+                # the energy file and uses it as the per-state shift internally.
+                dict_mod["SpectrumLoopExct"] = [exct]
+            else:
+                dict_mod["OmegaOrg"] = [self.energy_list[exct], 0]
             if ex_state == 0:
                 omega_max = dict_mod["OmegaMax"]
                 dict_mod["OmegaMax"] = [-1.0*float(omega_max[0]), -1.0*float(omega_max[1])]
@@ -284,14 +312,22 @@ class CalcSpectrumCore:
 
     def _run_HPhi(self, exct_cut, ex_state=0, calc_dir="./"):
         os.chdir(calc_dir)
-        for idx in range(exct_cut):
-            self._update_modpara(idx, ex_state, calc_dir)
-            input_path = os.path.join(calc_dir, "namelist_ex_{}.def".format(idx))
-            exec_path = self.path_to_HPhi
-            cmd = "{} {} -e {} > std_{}.log".format(self.mpi_prefix, exec_path, input_path, idx).strip()
+        exec_path = self.path_to_HPhi
+        if self.internal_loop:
+            # One launch covers all exct_cut eigenstates; HPhi writes
+            # output/<header>_DynamicalGreen_<idx>.dat directly (no per-idx rename).
+            self._update_modpara(exct_cut, ex_state, calc_dir)
+            input_path = os.path.join(calc_dir, "namelist_ex.def")
+            cmd = "{} {} -e {} > std.log".format(self.mpi_prefix, exec_path, input_path).strip()
             subprocess.call(cmd, shell=True)
-            cmd = "mv ./output/{0}_DynamicalGreen.dat ./output/{0}_DynamicalGreen_{1}.dat".format(self.header, idx)
-            subprocess.call(cmd, shell=True)
+        else:
+            for idx in range(exct_cut):
+                self._update_modpara(idx, ex_state, calc_dir)
+                input_path = os.path.join(calc_dir, "namelist_ex_{}.def".format(idx))
+                cmd = "{} {} -e {} > std_{}.log".format(self.mpi_prefix, exec_path, input_path, idx).strip()
+                subprocess.call(cmd, shell=True)
+                cmd = "mv ./output/{0}_DynamicalGreen.dat ./output/{0}_DynamicalGreen_{1}.dat".format(self.header, idx)
+                subprocess.call(cmd, shell=True)
         os.chdir(self.parent_dir)
 
     def get_one_body_green_core(self, sitei, sigmai, sitej, sigmaj, ex_state, flg, exct_cut):

--- a/src/dcore/impurity_solvers/hphi_spectrum.py
+++ b/src/dcore/impurity_solvers/hphi_spectrum.py
@@ -6,10 +6,17 @@ import sys
 
 # T_list, n_iw, exct, eta, path_to_HPhi="./HPhi", header="zvo", output_dir="./output"
 
-def calc_one_body_green_core_parallel(p_common, max_workers=None):
+def calc_one_body_green_core_parallel(p_common, max_workers=None, sector_occupancy=None):
     """
     Return:
         np.ndarray(n_site, n_sigma, n_site, n_sigma, n_T, n_omega)
+
+    sector_occupancy: optional (n_up, n_down, n_site) for the canonical (sector-resolved)
+        path. When given, operators with an exactly-zero contribution in that (Ne, 2Sz)
+        sector -- cross-spin off-diagonal terms (zero by spin conservation), and
+        annihilation/creation on an already empty/full spin -- are skipped instead of run,
+        which also avoids HPhi excitations into non-existent sectors. Their contribution is
+        filled with zeros. None (default) is the grand-canonical path: every operator runs.
     """
 
     n_sigma = 2
@@ -42,16 +49,25 @@ def calc_one_body_green_core_parallel(p_common, max_workers=None):
     from concurrent.futures import ProcessPoolExecutor
     import shutil
 
+    # In the canonical path, only operators with a non-zero contribution in this sector are
+    # run; the rest are filled with zeros below. In the grand-canonical path all tasks run.
+    if sector_occupancy is not None:
+        run_tasks = [t for t in tasks if _task_valid_in_sector(t, *sector_occupancy)]
+        if not run_tasks:
+            raise RuntimeError("No valid excitation operator for sector {}.".format(sector_occupancy))
+    else:
+        run_tasks = tasks
+
     internal_loop = os.environ.get("DCORE_HPHI_INTERNAL_LOOP", "0") == "1"
     if internal_loop:
         # Group operators by Hilbert sector so each HPhi run reads every eigenvector
         # once and reuses it across all operators of that sector (op-inner). Each
         # batch is one HPhi launch; the pool parallelizes over batches.
-        batches = _group_tasks_by_sector(tasks)
+        batches = _group_tasks_by_sector(run_tasks)
         cleanup_dirs = ["batch_{}".format(bid) for bid in range(len(batches))]
     else:
         cleanup_dirs = ["{}_{}_{}_{}_{}_{}".format(t[0], t[1], t[2], t[3], t[5], t[4])
-                        for t in tasks]
+                        for t in run_tasks]
 
     try:
         if internal_loop:
@@ -60,14 +76,18 @@ def calc_one_body_green_core_parallel(p_common, max_workers=None):
             result_map = {}
             for out in batch_outputs:
                 result_map.update(out)
-            assert len(result_map) == len(tasks), \
-                "batched routing covered {} of {} tasks".format(len(result_map), len(tasks))
-            results = [result_map[_task_key(t)] for t in tasks]
         else:
             with ProcessPoolExecutor(max_workers=max_workers) as executor:
-                results = list(executor.map(calc_one_body_green_core, tasks))
+                run_results = list(executor.map(calc_one_body_green_core, run_tasks))
+            result_map = {_task_key(t): r for t, r in zip(run_tasks, run_results)}
 
-        n_omega = results[0].shape[-1]
+        assert len(result_map) == len(run_tasks), \
+            "routing covered {} of {} run tasks".format(len(result_map), len(run_tasks))
+        n_omega = next(iter(result_map.values())).shape[-1]
+        # tasks not run (filtered out as exactly zero in this sector) contribute zeros.
+        zero = np.zeros((len(T_list), n_omega), dtype=np.complex128)
+        results = [result_map.get(_task_key(t), zero) for t in tasks]
+
         one_body_green_core = np.zeros(
             (n_site, n_sigma, n_site, n_sigma, n_flg, n_excitation, len(T_list), n_omega),
             dtype=np.complex128)
@@ -80,6 +100,24 @@ def calc_one_body_green_core_parallel(p_common, max_workers=None):
                 shutil.rmtree(dir_path)
 
     return one_body_green
+
+
+def _task_valid_in_sector(task, n_up, n_down, n_site):
+    """Whether a one-body-Gf operator has a non-zero contribution in a canonical (Ne, 2Sz) sector.
+
+    Cross-spin off-diagonal operators (sigma_i != sigma_j) vanish by spin conservation and would
+    map to two different Sz sectors, so the c_i + i c_j combination is ill-defined canonically.
+    A same-spin operator excites spin sigma: annihilation (ex_state 0) needs that spin occupied
+    (n_sigma >= 1); creation (ex_state 1) needs a free slot (n_sigma <= n_site - 1). Otherwise the
+    excited state is zero (and HPhi would excite into a non-existent sector).
+    """
+    sitei, sigmai, sitej, sigmaj, idx_flg, ex_state = task[:6]
+    if sigmai != sigmaj:
+        return False
+    n_sigma = n_up if sigmai == 0 else n_down
+    if ex_state == 0:  # annihilation c_sigma
+        return n_sigma >= 1
+    return n_sigma <= n_site - 1  # creation c_sigma^dagger
 
 
 def _task_key(task):
@@ -283,8 +321,11 @@ class CalcSpectrumCore:
                 if len(words) != 0 and words[0] == "Energy":
                     energy_list.append(float(words[1]))
         self.energy_list = energy_list
-        self.ene_min = energy_list[0]
-        self.ene_max = energy_list[len(energy_list)-1]
+        # Use min/max (not [0]/[-1]) so the sector-local Boltzmann normalization here matches the
+        # cross-sector recombination in the canonical solver, which uses energies.min(), even if
+        # zvo_energy.dat were ever written out of energy order.
+        self.ene_min = min(energy_list)
+        self.ene_max = max(energy_list)
 
         if check_eta:
             print(f"\n  Check eta:=exp[-beta(ene_max-ene_mix)] < {self.eta:.1e}")

--- a/src/dcore/impurity_solvers/hphi_spectrum.py
+++ b/src/dcore/impurity_solvers/hphi_spectrum.py
@@ -19,27 +19,42 @@ def calc_one_body_green_core_parallel(p_common, max_workers=None):
 
     check_eta(p_common)
 
+    def composite(site, sigma):
+        return site * n_sigma + sigma
+
     def gen_p():
         for sitei, sigmai in itertools.product(range(n_site), range(n_sigma)):
             for sitej, sigmaj in itertools.product(range(n_site), range(n_sigma)):
-                    for idx, flg in enumerate([True, False]):
-                        for ex_state in range(n_excitation):
-                            yield sitei, sigmai, sitej, sigmaj, idx, ex_state, p_common
+                # Only the upper triangle (a_i <= a_j) is computed; the transposed
+                # element G_ji is reconstructed from the same excitation data.
+                if composite(sitei, sigmai) > composite(sitej, sigmaj):
+                    continue
+                for idx, flg in enumerate([True, False]):
+                    for ex_state in range(n_excitation):
+                        # On the diagonal only the flg=True (idx=0) excitation is used.
+                        if composite(sitei, sigmai) == composite(sitej, sigmaj) and idx == 1:
+                            continue
+                        yield sitei, sigmai, sitej, sigmaj, idx, ex_state, p_common
 
+    tasks = list(gen_p())
+    if not tasks:
+        raise ValueError("No excitation tasks were generated (n_site must be >= 1).")
     from concurrent.futures import ProcessPoolExecutor
     with ProcessPoolExecutor(max_workers=max_workers) as executor:
-        one_body_g_tmp = np.array(list(executor.map(calc_one_body_green_core, gen_p())))
-    n_omega = one_body_g_tmp.shape[2]
-    one_body_green_core = one_body_g_tmp.reshape((n_site, n_sigma, n_site, n_sigma, n_flg, n_excitation, len(T_list), n_omega))
+        results = list(executor.map(calc_one_body_green_core, tasks))
+
+    n_omega = results[0].shape[-1]
+    one_body_green_core = np.zeros(
+        (n_site, n_sigma, n_site, n_sigma, n_flg, n_excitation, len(T_list), n_omega),
+        dtype=np.complex128)
+    for (sitei, sigmai, sitej, sigmaj, idx, ex_state, _), res in zip(tasks, results):
+        one_body_green_core[sitei][sigmai][sitej][sigmaj][idx][ex_state] = res
     one_body_green = calc_one_body_green(one_body_green_core)
 
     import shutil
-    for sitei, sigmai in itertools.product(range(n_site), range(n_sigma)):
-        for sitej, sigmaj in itertools.product(range(n_site), range(n_sigma)):
-            for idx in range(n_flg):
-                for ex_state in range(n_excitation):
-                    dir_path = "{}_{}_{}_{}_{}_{}".format(sitei, sigmai, sitej, sigmaj, ex_state, idx)
-                    shutil.rmtree(dir_path)
+    for sitei, sigmai, sitej, sigmaj, idx, ex_state, _ in tasks:
+        dir_path = "{}_{}_{}_{}_{}_{}".format(sitei, sigmai, sitej, sigmaj, ex_state, idx)
+        shutil.rmtree(dir_path)
 
     return one_body_green
 
@@ -70,59 +85,26 @@ def calc_one_body_green(one_body_green_core):
     for sitei, sigmai, ex_state in itertools.product(range(n_site), range(n_sigma), range(n_excitation)):
         one_body_green[sitei][sigmai][sitei][sigmai] += one_body_green_core[sitei][sigmai][sitei][sigmai][0][ex_state]
 
-    # Off diagonal
+    # Off diagonal: only the upper triangle (a_i < a_j) is reconstructed; each
+    # iteration fills both G_ij and the transposed G_ji from the same data.
     for sitei, sigmai, sitej, sigmaj  in itertools.product(range(n_site), range(n_sigma), range(n_site), range(n_sigma)):
+        if sitei * n_sigma + sigmai >= sitej * n_sigma + sigmaj:
+            continue  # diagonal is set above; lower triangle is set via its transpose
         one_body_green_tmp = np.zeros((n_flg, n_T, n_omega), dtype=np.complex128)
         for idx in range(n_flg):
             for ex_state in range(n_excitation):
                 one_body_green_tmp[idx] += one_body_green_core[sitei][sigmai][sitej][sigmaj][idx][ex_state]
-            one_body_green_tmp[1] -= one_body_green[sitei][sigmai][sitei][sigmai] + \
-                                     one_body_green[sitej][sigmaj][sitej][sigmaj]
-            one_body_green[sitei][sigmai][sitej][sigmaj] = (one_body_green_tmp[0] + 1J * one_body_green_tmp[
-                1]) / 2.0
-            one_body_green[sitei][sigmai][sitej][sigmaj] = (one_body_green_tmp[0] - 1J * one_body_green_tmp[
-                1]) / 2.0
+        # Subtract the diagonal contribution from both combinations
+        #   B = c_i + c_j   -> tmp[1] - (G_ii + G_jj) = G_ij + G_ji
+        #   A = c_i + i c_j -> tmp[0] - (G_ii + G_jj) = i (G_ji - G_ij)
+        diag = one_body_green[sitei][sigmai][sitei][sigmai] + \
+               one_body_green[sitej][sigmaj][sitej][sigmaj]
+        one_body_green_tmp[0] -= diag
+        one_body_green_tmp[1] -= diag
+        one_body_green[sitei][sigmai][sitej][sigmaj] = (one_body_green_tmp[1] + 1J * one_body_green_tmp[0]) / 2.0
+        one_body_green[sitej][sigmaj][sitei][sigmai] = (one_body_green_tmp[1] - 1J * one_body_green_tmp[0]) / 2.0
     return one_body_green
 
-
-class CalcSpectrum:
-    def __init__(self, T_list, n_iw, exct, eta, path_to_HPhi="./HPhi", header="zvo", output_dir="./output"):
-        self.T_list = T_list
-        self.exct = exct
-        self.eta = eta
-        self.header = header
-        self.output_dir = output_dir
-        self.path_to_HPhi = os.path.abspath(path_to_HPhi)
-        self.calc_spectrum_core = CalcSpectrumCore(T_list, exct, eta, path_to_HPhi="./HPhi", header="zvo", output_dir="./output")
-        self.nomega = n_iw
-
-    def get_one_body_green_core(self, n_site, exct_cut):
-        self.calc_spectrum_core.set_energies()
-        n_excitation = 2 # type of excitation operator
-        n_flg = 2
-        n_sigma = 2
-        one_body_green = np.zeros((n_site, n_sigma, n_site, n_sigma, len(self.T_list), self.nomega), dtype=np.complex128)
-        one_body_green_core = np.zeros((n_site, n_sigma, n_site, n_sigma, n_flg, n_excitation, len(self.T_list), self.nomega), dtype=np.complex128)
-
-        for sitei, sigmai, sitej, sigmaj  in itertools.product(range(n_site), range(n_sigma), range(n_site), range(n_sigma)):
-            for idx, flg in enumerate([True, False]):
-                for ex_state in range(n_excitation):
-                    one_body_green_core[sitei][sigmai][sitej][sigmaj][idx][ex_state] = self.calc_spectrum_core.get_one_body_green_core(sitei, sigmai, sitej, sigmaj, ex_state, flg, exct_cut)
-
-        #Diagonal
-        for sitei, sigmai, ex_state in itertools.product(range(n_site), range(n_sigma), range(n_excitation)):
-            one_body_green[sitei][sigmai][sitei][sigmai] += one_body_green_core[sitei][sigmai][sitei][sigmai][0][ex_state]
-
-        # Off diagonal
-        for sitei, sigmai, sitej, sigmaj in itertools.product(range(n_site), range(n_sigma),range(n_site), range(n_sigma)):
-            one_body_green_tmp = np.zeros((n_flg, len(self.T_list), self.nomega), dtype=np.complex128)
-            for idx in range(n_flg):
-                for ex_state in range(n_excitation):
-                    one_body_green_tmp[idx] += one_body_green_core[sitei][sigmai][sitej][sigmaj][idx][ex_state]
-                one_body_green_tmp[1] -= one_body_green[sitei][sigmai][sitei][sigmai] + one_body_green[sitej][sigmaj][sitej][sigmaj]
-                one_body_green[sitei][sigmai][sitej][sigmaj] = (one_body_green_tmp[0] + 1J * one_body_green_tmp[1]) / 2.0
-                one_body_green[sitei][sigmai][sitej][sigmaj] = (one_body_green_tmp[0] - 1J * one_body_green_tmp[1]) / 2.0
-        return one_body_green
 
 class CalcSpectrumCore:
     def __init__(self, T_list, exct, eta, path_to_HPhi="./HPhi", header="zvo", output_dir="./output"):
@@ -338,12 +320,6 @@ def test_main():
     output_dir = dict_toml.get("output_dir", "./output")
     n_site = dict_toml.get("n_site", 2)
     max_workers=4
-
-    #Calculate one body Green's functions directly
-    # calcg = CalcSpectrum(T_list, NOmega, exct, eta, path_to_HPhi, header, output_dir)
-    # one_body_g_direct = calcg.get_one_body_green(n_site, exct)
-    # print(one_body_g_direct)
-    # exit(0)
 
     #Calculate one body Green's functions using parallel
     n_sigma = 2

--- a/src/dcore/impurity_solvers/hphi_spectrum.py
+++ b/src/dcore/impurity_solvers/hphi_spectrum.py
@@ -15,7 +15,7 @@ def calc_one_body_green_core_parallel(p_common, max_workers=None):
     n_sigma = 2
     n_flg = 2
     n_excitation = 2
-    n_site, T_list, exct, eta, path_to_HPhi, header, output_dir, exct_cut = p_common
+    n_site, T_list, exct, eta, path_to_HPhi, header, output_dir, exct_cut, *rest = p_common
 
     check_eta(p_common)
 
@@ -61,18 +61,20 @@ def calc_one_body_green_core_parallel(p_common, max_workers=None):
 def calc_one_body_green_core(p):
     #unpack parameters
     sitei, sigmai, sitej, sigmaj, i_flg, ex_state, p_common = p
-    n_site, T_list, exct, eta, path_to_HPhi, header, output_dir, exct_cut = p_common
+    n_site, T_list, exct, eta, path_to_HPhi, header, output_dir, exct_cut, *rest = p_common
+    mpi_prefix = rest[0] if rest else ""
     calc_spectrum_core = CalcSpectrumCore(T_list, exct, eta, path_to_HPhi=path_to_HPhi, header=header,
-                                           output_dir=output_dir)
+                                           output_dir=output_dir, mpi_prefix=mpi_prefix)
 
     calc_spectrum_core.set_energies()
     flg = True if i_flg == 0 else False
     return calc_spectrum_core.get_one_body_green_core(sitei, sigmai, sitej, sigmaj, ex_state, flg, exct_cut)
 
 def check_eta(p_common):
-    _, T_list, exct, eta, path_to_HPhi, header, output_dir, _ = p_common
+    _, T_list, exct, eta, path_to_HPhi, header, output_dir, _, *rest = p_common
+    mpi_prefix = rest[0] if rest else ""
     calc_spectrum_core = CalcSpectrumCore(T_list, exct, eta, path_to_HPhi=path_to_HPhi, header=header,
-                                           output_dir=output_dir)
+                                           output_dir=output_dir, mpi_prefix=mpi_prefix)
     calc_spectrum_core.set_energies(check_eta=True)
 
 def calc_one_body_green(one_body_green_core):
@@ -107,7 +109,7 @@ def calc_one_body_green(one_body_green_core):
 
 
 class CalcSpectrumCore:
-    def __init__(self, T_list, exct, eta, path_to_HPhi="./HPhi", header="zvo", output_dir="./output"):
+    def __init__(self, T_list, exct, eta, path_to_HPhi="./HPhi", header="zvo", output_dir="./output", mpi_prefix=""):
         self.T_list = T_list
         self.exct = exct
         self.eta = eta
@@ -117,6 +119,9 @@ class CalcSpectrumCore:
         self.parent_dir = os.getcwd()
         # self.path_to_HPhi = os.path.join(self.parent_dir, path_to_HPhi)
         self.path_to_HPhi = os.path.abspath(path_to_HPhi)  # converted to full path in DCore
+        # MPI launcher for each HPhi run of the Gf step (e.g. "mpirun -np 4");
+        # empty string runs HPhi serially (one rank, no mpirun).
+        self.mpi_prefix = mpi_prefix
 
     def Make_Spectrum_Input(self, calc_dir="./", spectrum_type="single"):
 
@@ -283,7 +288,7 @@ class CalcSpectrumCore:
             self._update_modpara(idx, ex_state, calc_dir)
             input_path = os.path.join(calc_dir, "namelist_ex_{}.def".format(idx))
             exec_path = self.path_to_HPhi
-            cmd = "{} -e {} > std_{}.log".format(exec_path, input_path, idx)
+            cmd = "{} {} -e {} > std_{}.log".format(self.mpi_prefix, exec_path, input_path, idx).strip()
             subprocess.call(cmd, shell=True)
             cmd = "mv ./output/{0}_DynamicalGreen.dat ./output/{0}_DynamicalGreen_{1}.dat".format(self.header, idx)
             subprocess.call(cmd, shell=True)

--- a/src/dcore/impurity_solvers/hphi_spectrum.py
+++ b/src/dcore/impurity_solvers/hphi_spectrum.py
@@ -24,6 +24,24 @@ def calc_one_body_green_core_parallel(p_common, max_workers=None, sector_occupan
     n_excitation = 2
     n_site, T_list, exct, eta, path_to_HPhi, header, output_dir, exct_cut, *rest = p_common
 
+    if n_site < 1:
+        raise ValueError("No excitation tasks were generated (n_site must be >= 1).")
+
+    # Stage-3 direct bra/ket path (opt-in). One ket BiCG solve is projected onto all bras via
+    # HPhi's SpectrumNumBra, so off-diagonal G is read directly instead of reconstructed from the
+    # c_i + i c_j combination trick (BiCG count n_orb^2 -> n_orb). Default off = combination trick.
+    # These guards run before check_eta so the unsupported configurations fail cleanly.
+    if os.environ.get("DCORE_HPHI_BRAKET", "0") == "1":
+        # The bra/ket path is built on the per-(Ne, 2Sz) sector decomposition (the solver enables
+        # the canonical path whenever DCORE_HPHI_BRAKET=1). The grand-canonical route (all spins in
+        # one excited Fock space) is not supported here, so reject it explicitly rather than
+        # silently producing a wrong (zero-norm) Green's function.
+        if sector_occupancy is None:
+            raise RuntimeError("DCORE_HPHI_BRAKET=1 requires the canonical sector path "
+                               "(sector_occupancy); the grand-canonical bra/ket route is unsupported.")
+        check_eta(p_common)
+        return _braket_one_body_green(p_common, max_workers, sector_occupancy)
+
     check_eta(p_common)
 
     def composite(site, sigma):
@@ -176,6 +194,92 @@ def calc_one_body_green_batch(payload):
         "batch {}: got {} results for {} operators".format(batch_id, len(res_list), len(batch))
     return {_task_key(t): r for t, r in zip(batch, res_list)}
 
+def calc_one_body_green_braket_job(payload):
+    """Run one HPhi braket launch (all kets x all bras) for one ex_state sector.
+
+    payload = (job_id, ex_state, ket_ops, bra_ops, p_common); ops are (site, sigma).
+    Returns {(bra_op, ket_op): one_body_green} (the sign for this ex_state is already applied).
+    """
+    job_id, ex_state, ket_ops, bra_ops, p_common = payload
+    n_site, T_list, exct, eta, path_to_HPhi, header, output_dir, exct_cut, *rest = p_common
+    mpi_prefix = rest[0] if rest else ""
+    core = CalcSpectrumCore(T_list, exct, eta, path_to_HPhi=path_to_HPhi, header=header,
+                            output_dir=output_dir, mpi_prefix=mpi_prefix)
+    core.set_energies()
+    return core.get_one_body_green_braket_batch(ex_state, ket_ops, bra_ops, exct_cut, batch_id=job_id)
+
+
+def _braket_sector_jobs(n_site, sector_occupancy):
+    """Enumerate the (ex_state, ket_ops, bra_ops) launches of the direct bra/ket path.
+
+    One launch per (ex_state, spin): ket_ops = bra_ops = [(0, sigma), .., (n_site-1, sigma)] so the
+    full same-spin G block is obtained from n_site solves. sector_occupancy = (n_up, n_down, n_site)
+    drops (ex_state, spin) sectors whose excited state vanishes (annihilation on an empty spin or
+    creation on a full one); None (grand canonical) keeps every (ex_state, spin). Cross-spin
+    elements are never generated (zero by spin conservation; dropped from the final Gimp anyway).
+    """
+    n_sigma = 2
+    n_excitation = 2
+    jobs = []
+    for ex_state in range(n_excitation):
+        for sigma in range(n_sigma):
+            if sector_occupancy is not None:
+                n_up, n_down, nsite = sector_occupancy
+                n_s = n_up if sigma == 0 else n_down
+                # annihilation needs the spin occupied; creation needs a free slot.
+                valid = (n_s >= 1) if ex_state == 0 else (n_s <= nsite - 1)
+                if not valid:
+                    continue
+            ops = [(site, sigma) for site in range(n_site)]
+            jobs.append((ex_state, ops, ops))
+    return jobs
+
+
+def _braket_one_body_green(p_common, max_workers, sector_occupancy):
+    """Stage-3 direct bra/ket one-body Green's function (DCORE_HPHI_BRAKET=1).
+
+    Replaces the c_i + i c_j combination trick: each ket solve is projected onto every bra,
+    so G_{i,j} is read directly (BiCG count n_orb^2 -> n_orb). Each launch handles ONE
+    (ex_state, spin) sector: kets = bras = {c_{0,sigma}..c_{n_site-1,sigma}} (same spin), so the
+    full same-spin G block comes from n_site solves. Cross-spin (sigma_i != sigma_j) elements are
+    zero by spin conservation and are not computed (the final Gimp keeps only same-spin blocks).
+    Grand canonical runs every (ex_state, spin); canonical skips (ex_state, spin) sectors that are
+    empty/full for that spin (their excited state would vanish).
+    """
+    n_sigma = 2
+    n_site, T_list, exct, eta, path_to_HPhi, header, output_dir, exct_cut, *rest = p_common
+
+    spec = _braket_sector_jobs(n_site, sector_occupancy)
+    if not spec:
+        raise RuntimeError("No valid braket excitation sector for {}.".format(sector_occupancy))
+    jobs = [(ex_state, ket_ops, bra_ops, p_common) for (ex_state, ket_ops, bra_ops) in spec]
+
+    from concurrent.futures import ProcessPoolExecutor
+    import shutil
+    payloads = [(jid,) + job for jid, job in enumerate(jobs)]
+    cleanup_dirs = ["braket_{}".format(jid) for jid in range(len(jobs))]
+    try:
+        with ProcessPoolExecutor(max_workers=max_workers) as executor:
+            results = list(executor.map(calc_one_body_green_braket_job, payloads))
+        sample = next(iter(results[0].values()))
+        n_T, n_omega = sample.shape
+        # Accumulate over ex_state (annihilation + creation) and, for grand canonical, over the
+        # both-spin job: each (bra_op, ket_op) appears once per ex_state job that contains it.
+        one_body_green = np.zeros((n_site, n_sigma, n_site, n_sigma, n_T, n_omega), dtype=np.complex128)
+        for res in results:
+            for (bra_op, ket_op), g in res.items():
+                (si, sgi) = bra_op
+                (sj, sgj) = ket_op
+                # g = G_{bra,ket} = <c_bra phi|R|c_ket phi>. The combination-trick path (validated
+                # vs scipy) stores this physical element at one_body_green[ket][bra], so match it.
+                one_body_green[sj][sgj][si][sgi] += g
+    finally:
+        for d in cleanup_dirs:
+            if os.path.isdir(d):
+                shutil.rmtree(d)
+    return one_body_green
+
+
 def check_eta(p_common):
     _, T_list, exct, eta, path_to_HPhi, header, output_dir, _, *rest = p_common
     mpi_prefix = rest[0] if rest else ""
@@ -235,7 +339,7 @@ class CalcSpectrumCore:
         # per-idx path (default) stays as the validated fallback / reference.
         self.internal_loop = os.environ.get("DCORE_HPHI_INTERNAL_LOOP", "0") == "1"
 
-    def Make_Spectrum_Input(self, calc_dir="./", spectrum_type="single"):
+    def Make_Spectrum_Input(self, calc_dir="./", spectrum_type="single", bra=False):
 
         rel_path_org = os.path.relpath(self.parent_dir, calc_dir)
         rel_path = os.path.relpath(os.path.join(self.parent_dir, "output"), calc_dir)
@@ -261,7 +365,8 @@ class CalcSpectrumCore:
                     if len(words) == 0:
                         continue
                     if words[0] in ["CalcMod", "SpectrumVec", "ModPara",
-                                    "SingleExcitation", "PairExcitation"]:
+                                    "SingleExcitation", "PairExcitation",
+                                    "SingleExcitationBra", "PairExcitationBra"]:
                         continue
                     fex.write("{} {}\n".format(words[0], os.path.join(rel_path_org, words[1])))
                 fex.write("ModPara modpara_ex.def\n")
@@ -269,6 +374,10 @@ class CalcSpectrumCore:
                 fex.write("SpectrumVec    {}\n".format(spectrum_vec))
                 if spectrum_type == "single":
                     fex.write("SingleExcitation single_ex.def\n")
+                    if bra:
+                        # Stage-3 bra/ket reuse: bra set 0 is the namelist SingleExcitationBra;
+                        # bra sets 1.. come from single_ex_bra_<b>.def (SpectrumNumBra).
+                        fex.write("SingleExcitationBra single_ex_bra_0.def\n")
                 elif spectrum_type == "pair":
                     fex.write("PairExcitation pair_ex.def\n")
 
@@ -362,7 +471,7 @@ class CalcSpectrumCore:
                 for idx, value in enumerate(spectrum):
                     fw.write("{} {} {} {}\n".format(self.frequencies[idx].real, self.frequencies[idx].imag, value.real, value.imag))
 
-    def _update_modpara(self, exct, ex_state=0, calc_dir="./", num_op=1):
+    def _update_modpara(self, exct, ex_state=0, calc_dir="./", num_op=1, num_bra=1):
         dict_mod={}
         header = []
         with open(os.path.join(self.parent_dir, "modpara.def"), "r") as fr:
@@ -379,6 +488,10 @@ class CalcSpectrumCore:
                     # HPhi evaluates num_op operator sets (op-inner) reading each
                     # eigenvector once; set 0 is single_ex.def, sets 1.. are single_ex_<op>.def.
                     dict_mod["SpectrumNumOp"] = [num_op]
+                if num_bra > 1:
+                    # Stage-3 bra/ket reuse: project each ket solve onto num_bra bras in one
+                    # BiCG run; set 0 is single_ex_bra_0.def, sets 1.. are single_ex_bra_<b>.def.
+                    dict_mod["SpectrumNumBra"] = [num_bra]
             else:
                 dict_mod["OmegaOrg"] = [self.energy_list[exct], 0]
             if ex_state == 0:
@@ -423,13 +536,13 @@ class CalcSpectrumCore:
                     fw.write("{} {} {} 1.0 0.0\n".format(site_i, sigma_i, ex_state))
                     fw.write("{} {} {} 1.0 0.0\n".format(site_j, sigma_j, ex_state))
 
-    def _run_HPhi(self, exct_cut, ex_state=0, calc_dir="./", num_op=1):
+    def _run_HPhi(self, exct_cut, ex_state=0, calc_dir="./", num_op=1, num_bra=1):
         os.chdir(calc_dir)
         exec_path = self.path_to_HPhi
         if self.internal_loop:
-            # One launch covers all exct_cut eigenstates (and all num_op operator sets);
-            # HPhi writes output/<header>_DynamicalGreen_<idx>[_<op>].dat directly.
-            self._update_modpara(exct_cut, ex_state, calc_dir, num_op=num_op)
+            # One launch covers all exct_cut eigenstates (and all num_op x num_bra operator
+            # sets); HPhi writes output/<header>_DynamicalGreen_<idx>[_<op>[_<bra>]].dat directly.
+            self._update_modpara(exct_cut, ex_state, calc_dir, num_op=num_op, num_bra=num_bra)
             input_path = os.path.join(calc_dir, "namelist_ex.def")
             cmd = "{} {} -e {} > std.log".format(self.mpi_prefix, exec_path, input_path).strip()
             ret = subprocess.call(cmd, shell=True)
@@ -527,6 +640,97 @@ class CalcSpectrumCore:
             for idx, T in enumerate(self.T_list):
                 one_body_green[idx] = sign * finite[op][T]
             out.append(one_body_green)
+        return out
+
+    def _finite_T_spectrum_braket(self, calc_dir, num_op, num_bra):
+        """Boltzmann-sum the per-(idx, op, bra) spectra written by a SpectrumNumBra run.
+
+        Returns (frequencies, {(op, bra, T): spectrum}). The file name matches HPhi's naming,
+        which depends on what is active: with num_bra > 1 it is
+        <header>_DynamicalGreen_<idx>_<op>_<bra>.dat (the _<op> field is forced on); with a single
+        operator AND single bra (num_op == num_bra == 1, e.g. a single-orbital impurity) HPhi
+        falls back to the unsuffixed <header>_DynamicalGreen_<idx>.dat.
+        """
+        spec_dir = os.path.join(calc_dir, self.output_dir)
+        use_bra = num_bra > 1
+        use_op = use_bra or num_op > 1
+        frequencies = None
+        raw = {}  # (op, bra, idx) -> complex spectrum
+        for op in range(num_op):
+            for b in range(num_bra):
+                for idx in range(self.exct):
+                    if use_bra:
+                        name = "{}_DynamicalGreen_{}_{}_{}.dat".format(self.header, idx, op, b)
+                    elif use_op:
+                        name = "{}_DynamicalGreen_{}_{}.dat".format(self.header, idx, op)
+                    else:
+                        name = "{}_DynamicalGreen_{}.dat".format(self.header, idx)
+                    d = np.loadtxt(os.path.join(spec_dir, name))
+                    raw[(op, b, idx)] = d[:, 2] + 1J * d[:, 3]
+                    if op == 0 and b == 0 and idx == 0:
+                        frequencies = d[:, 0] + 1J * d[:, 1]
+        finite = {}
+        for T in self.T_list:
+            Z = self._calc_Z(T)
+            weights = [np.exp(-(self.energy_list[idx] - self.ene_min) / T) for idx in range(self.exct)]
+            for op in range(num_op):
+                for b in range(num_bra):
+                    spectrum = np.zeros_like(raw[(op, b, 0)])
+                    for idx in range(self.exct):
+                        spectrum += weights[idx] * raw[(op, b, idx)]
+                    finite[(op, b, T)] = spectrum / Z
+        return frequencies, finite
+
+    def get_one_body_green_braket_batch(self, ex_state, ket_ops, bra_ops, exct_cut, batch_id=0):
+        """Stage-3 bra/ket reuse: ONE HPhi run that solves the resolvent for every ket
+        c_{j,sigma_j} (SpectrumNumOp) and projects each solve onto every bra c_{i,sigma_i}
+        (SpectrumNumBra), giving G_{i,j} = <c_i phi|(z-(H-E))^{-1}|c_j phi> directly -- no
+        c_i + i c_j combination trick. This cuts the BiCG count from n_orb^2 to n_orb.
+
+        ket_ops / bra_ops: lists of (site, sigma). For a canonical (Sz-resolved) sector both
+        lists are the sites of ONE spin; for grand canonical they are all 2*n_site spin-orbitals
+        (kets and bras of both spins share the Ne+-1 excited space). All ket/bra operators must
+        map to the same excited sector, which HPhi verifies (skipped for grand-canonical models).
+
+        Returns {(bra_op, ket_op): one_body_green[(n_T, n_omega)]} keyed by the (site, sigma)
+        tuples, i.e. G_{bra_op, ket_op}.
+        """
+        num_op = len(ket_ops)
+        num_bra = len(bra_ops)
+        calc_dir = os.path.join(self.parent_dir, "braket_{}".format(batch_id))
+        os.makedirs(calc_dir, exist_ok=True)
+        # The bra/ket projection rides on the SpectrumLoopExct internal eigenstate loop.
+        self.internal_loop = True
+        self.Make_Spectrum_Input(calc_dir, bra=True)
+        # kets: op 0 -> single_ex.def (the namelist SingleExcitation), ops 1.. -> single_ex_<k>.def
+        for k, (sj, sgj) in enumerate(ket_ops):
+            fname = "single_ex.def" if k == 0 else "single_ex_{}.def".format(k)
+            self._make_single_excitation(sj, sgj, sj, sgj, file_name=fname,
+                                         ex_state=ex_state, flg_complex=True, calc_dir=calc_dir)
+        # bras: bra b -> single_ex_bra_<b>.def (set 0 is the namelist SingleExcitationBra)
+        for b, (si, sgi) in enumerate(bra_ops):
+            self._make_single_excitation(si, sgi, si, sgi, file_name="single_ex_bra_{}.def".format(b),
+                                         ex_state=ex_state, flg_complex=True, calc_dir=calc_dir)
+        self._run_HPhi(exct_cut, ex_state, calc_dir, num_op=num_op, num_bra=num_bra)
+        frequencies, finite = self._finite_T_spectrum_braket(calc_dir, num_op, num_bra)
+        if ex_state == 1:
+            self.frequencies = frequencies
+        sign = 1.0 if ex_state == 1 else -1.0
+        out = {}
+        for k, ket_op in enumerate(ket_ops):
+            for b, bra_op in enumerate(bra_ops):
+                g = np.zeros((len(self.T_list), self.nomega), dtype=np.complex128)
+                for t_idx, T in enumerate(self.T_list):
+                    g[t_idx] = sign * finite[(k, b, T)]
+                # g = <c_bra phi|R|c_ket phi>. For the annihilation channel (ex_state 0) this is
+                # the physical element G_{bra,ket} that DCore stores at one_body_green[ket][bra]
+                # (see _braket_one_body_green). The creation channel (ex_state 1) builds the bra and
+                # ket from c^dag operators, whose ordering reverses the two indices, so its
+                # off-diagonal element is the transpose; emit it with bra/ket swapped so both
+                # channels accumulate into the same convention. Verified element-wise (to 1e-10)
+                # against the combination-trick path and end-to-end vs scipy/sparse.
+                key = (ket_op, bra_op) if ex_state == 1 else (bra_op, ket_op)
+                out[key] = g
         return out
 
 

--- a/src/dcore/impurity_solvers/hphi_spectrum.py
+++ b/src/dcore/impurity_solvers/hphi_spectrum.py
@@ -264,8 +264,15 @@ class CalcSpectrumCore:
                 fw.write("{} {} {} 1.0 0.0\n".format(site_i, sigma_i, ex_state))
             else:
                 if flg_complex is True:
+                    # A = c_i + i c_j (annihilation, ex_state=0), whose conjugate
+                    # excitation A^dag = c_i^dag - i c_j^dag (creation, ex_state=1).
+                    # The imaginary coefficient of c_j must be conjugated for the
+                    # creation channel, otherwise the anti-symmetric (imaginary)
+                    # part of the off-diagonal Green's function gets the wrong
+                    # high-frequency tail. (ex_state: 0 = c, 1 = c^dag)
+                    imag_coeff = -1.0 if ex_state == 1 else 1.0
                     fw.write("{} {} {} 1.0 0.0\n".format(site_i, sigma_i, ex_state))
-                    fw.write("{} {} {} 0.0 1.0\n".format(site_j, sigma_j, ex_state))
+                    fw.write("{} {} {} 0.0 {}\n".format(site_j, sigma_j, ex_state, imag_coeff))
                 else:
                     fw.write("{} {} {} 1.0 0.0\n".format(site_i, sigma_i, ex_state))
                     fw.write("{} {} {} 1.0 0.0\n".format(site_j, sigma_j, ex_state))

--- a/src/dcore/impurity_solvers/hphi_spectrum.py
+++ b/src/dcore/impurity_solvers/hphi_spectrum.py
@@ -6,7 +6,7 @@ import sys
 
 # T_list, n_iw, exct, eta, path_to_HPhi="./HPhi", header="zvo", output_dir="./output"
 
-def calc_one_body_green_core_parallel(p_common, max_workers=None, sector_occupancy=None):
+def calc_one_body_green_core_parallel(p_common, max_workers=None, sector_occupancy=None, ne_only=None):
     """
     Return:
         np.ndarray(n_site, n_sigma, n_site, n_sigma, n_T, n_omega)
@@ -17,6 +17,11 @@ def calc_one_body_green_core_parallel(p_common, max_workers=None, sector_occupan
         annihilation/creation on an already empty/full spin -- are skipped instead of run,
         which also avoids HPhi excitations into non-existent sectors. Their contribution is
         filled with zeros. None (default) is the grand-canonical path: every operator runs.
+
+    ne_only: optional total electron number Ne of a 2Sz-free (HubbardNConserved) sector, for the
+        spin-orbit bra/ket route (DCORE_HPHI_BRAKET=1 with spin-orbit). Both spins share the
+        Ne+-1 excited space, so cross-spin G elements are computed too. Mutually exclusive with
+        sector_occupancy; only meaningful on the braket path.
     """
 
     n_sigma = 2
@@ -32,15 +37,16 @@ def calc_one_body_green_core_parallel(p_common, max_workers=None, sector_occupan
     # c_i + i c_j combination trick (BiCG count n_orb^2 -> n_orb). Default off = combination trick.
     # These guards run before check_eta so the unsupported configurations fail cleanly.
     if os.environ.get("DCORE_HPHI_BRAKET", "0") == "1":
-        # The bra/ket path is built on the per-(Ne, 2Sz) sector decomposition (the solver enables
-        # the canonical path whenever DCORE_HPHI_BRAKET=1). The grand-canonical route (all spins in
-        # one excited Fock space) is not supported here, so reject it explicitly rather than
-        # silently producing a wrong (zero-norm) Green's function.
-        if sector_occupancy is None:
-            raise RuntimeError("DCORE_HPHI_BRAKET=1 requires the canonical sector path "
-                               "(sector_occupancy); the grand-canonical bra/ket route is unsupported.")
+        # The bra/ket path runs on a sector decomposition: per (Ne, 2Sz) for the 2Sz-conserving
+        # case (same-spin only), or per Ne (ne_only) for the spin-orbit / HubbardNConserved case
+        # (both spins, cross-spin G included). The grand-canonical route (all spins in one excited
+        # Fock space without sectoring) is not supported -- reject it rather than silently
+        # producing a wrong (zero-norm) Green's function.
+        if ne_only is None and sector_occupancy is None:
+            raise RuntimeError("DCORE_HPHI_BRAKET=1 requires a sector (sector_occupancy or "
+                               "ne_only); the grand-canonical bra/ket route is unsupported.")
         check_eta(p_common)
-        return _braket_one_body_green(p_common, max_workers, sector_occupancy)
+        return _braket_one_body_green(p_common, max_workers, sector_occupancy, ne_only=ne_only)
 
     check_eta(p_common)
 
@@ -235,23 +241,91 @@ def _braket_sector_jobs(n_site, sector_occupancy):
     return jobs
 
 
-def _braket_one_body_green(p_common, max_workers, sector_occupancy):
+def _braket_ne_sector_jobs(n_site, ne):
+    """Bra/ket launches for ONE Ne-only sector (2Sz-free, HubbardNConserved) -- the spin-orbit
+    capable route. With only Ne fixed, both spins share the Ne+-1 excited space, so each launch's
+    kets = bras = ALL 2*n_site spin-orbitals (both spins); one ket solve then yields the same-spin
+    AND cross-spin G_{i sigma_i, j sigma_j} elements. One launch per ex_state: annihilation (0)
+    needs an electron to remove (Ne >= 1); creation (1) needs a free slot (Ne <= 2*n_site - 1).
+    """
+    n_sigma = 2
+    n_so = n_sigma * n_site
+    if not 0 <= ne <= n_so:
+        raise ValueError("ne must be in [0, 2*n_site] = [0, {}], got {}".format(n_so, ne))
+    jobs = []
+    for ex_state in range(2):
+        valid = (ne >= 1) if ex_state == 0 else (ne <= n_so - 1)
+        if not valid:
+            continue
+        ops = [(site, sigma) for site in range(n_site) for sigma in range(n_sigma)]
+        jobs.append((ex_state, ops, ops))
+    return jobs
+
+
+def _braket_store_op(bra_op, ket_op, ex_state):
+    """Where the bra/ket element g = G_{bra,ket} = <c_bra phi|R|c_ket phi> is stored in
+    one_body_green, as a (row_op, col_op) pair of (site, sigma) tuples.
+
+    The annihilation channel (ex_state 0) stores the physical element at one_body_green[ket][bra]
+    -- the convention the validated combination-trick path uses. The creation channel (ex_state 1)
+    builds bra and ket from c^dag operators, whose ordering reverses the two indices, so it is the
+    transpose, stored at [bra][ket]. (For a diagonal element bra == ket the two coincide.) This is
+    the SAME convention for same-spin and cross-spin elements; it was verified element-wise (to
+    1e-10) against the combination trick / scipy for the same-spin blocks, and the cross-spin
+    blocks (Ne-only route) rely on the identical operator-ordering argument.
+    """
+    return (ket_op, bra_op) if ex_state == 0 else (bra_op, ket_op)
+
+
+def _braket_assemble(results, n_site):
+    """Accumulate the per-launch braket results into the one_body_green tensor.
+
+    ``results`` is a list of dicts ``{(row_op, col_op): g}`` (one per HPhi launch), where row_op /
+    col_op are (site, sigma) storage indices already produced by _braket_store_op (so the
+    creation-channel transpose is baked in). Returns one_body_green of shape
+    (n_site, 2, n_site, 2, n_T, n_omega); a given (row_op, col_op) accumulates across ex_state
+    launches (annihilation + creation) and, in the Ne-only route, across the both-spin job.
+    """
+    n_sigma = 2
+    sample = next(iter(results[0].values()))
+    n_T, n_omega = sample.shape
+    one_body_green = np.zeros((n_site, n_sigma, n_site, n_sigma, n_T, n_omega), dtype=np.complex128)
+    for res in results:
+        for (row_op, col_op), g in res.items():
+            (ri, rsg) = row_op
+            (ci, csg) = col_op
+            one_body_green[ri][rsg][ci][csg] += g
+    return one_body_green
+
+
+def _braket_one_body_green(p_common, max_workers, sector_occupancy, ne_only=None):
     """Stage-3 direct bra/ket one-body Green's function (DCORE_HPHI_BRAKET=1).
 
     Replaces the c_i + i c_j combination trick: each ket solve is projected onto every bra,
-    so G_{i,j} is read directly (BiCG count n_orb^2 -> n_orb). Each launch handles ONE
-    (ex_state, spin) sector: kets = bras = {c_{0,sigma}..c_{n_site-1,sigma}} (same spin), so the
-    full same-spin G block comes from n_site solves. Cross-spin (sigma_i != sigma_j) elements are
-    zero by spin conservation and are not computed (the final Gimp keeps only same-spin blocks).
-    Grand canonical runs every (ex_state, spin); canonical skips (ex_state, spin) sectors that are
-    empty/full for that spin (their excited state would vanish).
+    so G_{i,j} is read directly (BiCG count n_orb^2 -> n_orb).
+
+    Two sector modes:
+    - (Ne, 2Sz) [default, ``ne_only=None``]: each launch handles one (ex_state, spin) sector,
+      kets = bras = the same-spin sites, so the same-spin G block comes from n_site solves.
+      Cross-spin elements vanish by spin conservation and are not computed.
+    - Ne-only [``ne_only`` = the sector's Ne; for the spin-orbit / HubbardNConserved route]:
+      both spins share the Ne+-1 excited space, so each launch's kets = bras = ALL 2*n_site
+      spin-orbitals and one ket solve yields the same-spin AND cross-spin G elements.
     """
-    n_sigma = 2
     n_site, T_list, exct, eta, path_to_HPhi, header, output_dir, exct_cut, *rest = p_common
 
-    spec = _braket_sector_jobs(n_site, sector_occupancy)
+    if ne_only is not None:
+        # Ne-only mode is mutually exclusive with the (Ne, 2Sz) occupancy: the two describe
+        # different sector schemes, so a caller passing both is a bug, not a silent fallback.
+        if sector_occupancy is not None:
+            raise ValueError("ne_only and sector_occupancy are mutually exclusive "
+                             "(Ne-only vs (Ne, 2Sz) sectoring); got both.")
+        spec = _braket_ne_sector_jobs(n_site, ne_only)
+    else:
+        spec = _braket_sector_jobs(n_site, sector_occupancy)
     if not spec:
-        raise RuntimeError("No valid braket excitation sector for {}.".format(sector_occupancy))
+        raise RuntimeError("No valid braket excitation sector for occupancy={}, ne_only={}."
+                           .format(sector_occupancy, ne_only))
     jobs = [(ex_state, ket_ops, bra_ops, p_common) for (ex_state, ket_ops, bra_ops) in spec]
 
     from concurrent.futures import ProcessPoolExecutor
@@ -261,18 +335,7 @@ def _braket_one_body_green(p_common, max_workers, sector_occupancy):
     try:
         with ProcessPoolExecutor(max_workers=max_workers) as executor:
             results = list(executor.map(calc_one_body_green_braket_job, payloads))
-        sample = next(iter(results[0].values()))
-        n_T, n_omega = sample.shape
-        # Accumulate over ex_state (annihilation + creation) and, for grand canonical, over the
-        # both-spin job: each (bra_op, ket_op) appears once per ex_state job that contains it.
-        one_body_green = np.zeros((n_site, n_sigma, n_site, n_sigma, n_T, n_omega), dtype=np.complex128)
-        for res in results:
-            for (bra_op, ket_op), g in res.items():
-                (si, sgi) = bra_op
-                (sj, sgj) = ket_op
-                # g = G_{bra,ket} = <c_bra phi|R|c_ket phi>. The combination-trick path (validated
-                # vs scipy) stores this physical element at one_body_green[ket][bra], so match it.
-                one_body_green[sj][sgj][si][sgi] += g
+        one_body_green = _braket_assemble(results, n_site)
     finally:
         for d in cleanup_dirs:
             if os.path.isdir(d):
@@ -692,8 +755,9 @@ class CalcSpectrumCore:
         (kets and bras of both spins share the Ne+-1 excited space). All ket/bra operators must
         map to the same excited sector, which HPhi verifies (skipped for grand-canonical models).
 
-        Returns {(bra_op, ket_op): one_body_green[(n_T, n_omega)]} keyed by the (site, sigma)
-        tuples, i.e. G_{bra_op, ket_op}.
+        Returns {(row_op, col_op): one_body_green[(n_T, n_omega)]} where (row_op, col_op) is the
+        storage index of g = G_{bra_op, ket_op} given by _braket_store_op (which encodes the
+        creation-channel transpose); the caller accumulates one_body_green[row_op][col_op] += g.
         """
         num_op = len(ket_ops)
         num_bra = len(bra_ops)
@@ -722,15 +786,8 @@ class CalcSpectrumCore:
                 g = np.zeros((len(self.T_list), self.nomega), dtype=np.complex128)
                 for t_idx, T in enumerate(self.T_list):
                     g[t_idx] = sign * finite[(k, b, T)]
-                # g = <c_bra phi|R|c_ket phi>. For the annihilation channel (ex_state 0) this is
-                # the physical element G_{bra,ket} that DCore stores at one_body_green[ket][bra]
-                # (see _braket_one_body_green). The creation channel (ex_state 1) builds the bra and
-                # ket from c^dag operators, whose ordering reverses the two indices, so its
-                # off-diagonal element is the transpose; emit it with bra/ket swapped so both
-                # channels accumulate into the same convention. Verified element-wise (to 1e-10)
-                # against the combination-trick path and end-to-end vs scipy/sparse.
-                key = (ket_op, bra_op) if ex_state == 1 else (bra_op, ket_op)
-                out[key] = g
+                # Key by the storage index (which encodes the creation-channel transpose).
+                out[_braket_store_op(bra_op, ket_op, ex_state)] = g
         return out
 
 

--- a/src/dcore/impurity_solvers/hphi_spectrum.py
+++ b/src/dcore/impurity_solvers/hphi_spectrum.py
@@ -40,23 +40,71 @@ def calc_one_body_green_core_parallel(p_common, max_workers=None):
     if not tasks:
         raise ValueError("No excitation tasks were generated (n_site must be >= 1).")
     from concurrent.futures import ProcessPoolExecutor
-    with ProcessPoolExecutor(max_workers=max_workers) as executor:
-        results = list(executor.map(calc_one_body_green_core, tasks))
-
-    n_omega = results[0].shape[-1]
-    one_body_green_core = np.zeros(
-        (n_site, n_sigma, n_site, n_sigma, n_flg, n_excitation, len(T_list), n_omega),
-        dtype=np.complex128)
-    for (sitei, sigmai, sitej, sigmaj, idx, ex_state, _), res in zip(tasks, results):
-        one_body_green_core[sitei][sigmai][sitej][sigmaj][idx][ex_state] = res
-    one_body_green = calc_one_body_green(one_body_green_core)
-
     import shutil
-    for sitei, sigmai, sitej, sigmaj, idx, ex_state, _ in tasks:
-        dir_path = "{}_{}_{}_{}_{}_{}".format(sitei, sigmai, sitej, sigmaj, ex_state, idx)
-        shutil.rmtree(dir_path)
+
+    internal_loop = os.environ.get("DCORE_HPHI_INTERNAL_LOOP", "0") == "1"
+    if internal_loop:
+        # Group operators by Hilbert sector so each HPhi run reads every eigenvector
+        # once and reuses it across all operators of that sector (op-inner). Each
+        # batch is one HPhi launch; the pool parallelizes over batches.
+        batches = _group_tasks_by_sector(tasks)
+        cleanup_dirs = ["batch_{}".format(bid) for bid in range(len(batches))]
+    else:
+        cleanup_dirs = ["{}_{}_{}_{}_{}_{}".format(t[0], t[1], t[2], t[3], t[5], t[4])
+                        for t in tasks]
+
+    try:
+        if internal_loop:
+            with ProcessPoolExecutor(max_workers=max_workers) as executor:
+                batch_outputs = list(executor.map(calc_one_body_green_batch, list(enumerate(batches))))
+            result_map = {}
+            for out in batch_outputs:
+                result_map.update(out)
+            assert len(result_map) == len(tasks), \
+                "batched routing covered {} of {} tasks".format(len(result_map), len(tasks))
+            results = [result_map[_task_key(t)] for t in tasks]
+        else:
+            with ProcessPoolExecutor(max_workers=max_workers) as executor:
+                results = list(executor.map(calc_one_body_green_core, tasks))
+
+        n_omega = results[0].shape[-1]
+        one_body_green_core = np.zeros(
+            (n_site, n_sigma, n_site, n_sigma, n_flg, n_excitation, len(T_list), n_omega),
+            dtype=np.complex128)
+        for (sitei, sigmai, sitej, sigmaj, idx, ex_state, _), res in zip(tasks, results):
+            one_body_green_core[sitei][sigmai][sitej][sigmaj][idx][ex_state] = res
+        one_body_green = calc_one_body_green(one_body_green_core)
+    finally:
+        for dir_path in cleanup_dirs:
+            if os.path.isdir(dir_path):
+                shutil.rmtree(dir_path)
 
     return one_body_green
+
+
+def _task_key(task):
+    """Hashable identity of a task (drops the unhashable p_common)."""
+    return task[:6]
+
+
+def _group_tasks_by_sector(tasks):
+    """Group operators that can share one HPhi run (same Hilbert sector).
+
+    A single-excitation operator changes the electron number by +-1 in spin
+    sigma. Diagonal (c_{i,sigma}) and same-spin off-diagonal (c_{i,sigma} +
+    i c_{j,sigma}) operators map to the sector keyed by (ex_state, sigma) and are
+    batched together. Cross-spin off-diagonal operators (sigma_i != sigma_j) mix
+    Sz, so they are sector-inconsistent and run as singletons (one launch each).
+    """
+    groups = {}
+    singletons = []
+    for t in tasks:
+        sitei, sigmai, sitej, sigmaj, i_flg, ex_state, _ = t
+        if sigmai == sigmaj:
+            groups.setdefault((ex_state, sigmai), []).append(t)
+        else:
+            singletons.append([t])
+    return list(groups.values()) + singletons
 
 def calc_one_body_green_core(p):
     #unpack parameters
@@ -69,6 +117,26 @@ def calc_one_body_green_core(p):
     calc_spectrum_core.set_energies()
     flg = True if i_flg == 0 else False
     return calc_spectrum_core.get_one_body_green_core(sitei, sigmai, sitej, sigmaj, ex_state, flg, exct_cut)
+
+def calc_one_body_green_batch(payload):
+    """Run one HPhi launch for a batch of same-sector operators (op-inner reuse).
+
+    payload = (batch_id, batch); batch is a list of tasks sharing a Hilbert sector.
+    Returns {task_key: one_body_green} for every task in the batch.
+    """
+    batch_id, batch = payload
+    p_common = batch[0][6]
+    n_site, T_list, exct, eta, path_to_HPhi, header, output_dir, exct_cut, *rest = p_common
+    mpi_prefix = rest[0] if rest else ""
+    core = CalcSpectrumCore(T_list, exct, eta, path_to_HPhi=path_to_HPhi, header=header,
+                            output_dir=output_dir, mpi_prefix=mpi_prefix)
+    core.set_energies()
+    # (sitei, sigmai, sitej, sigmaj, ex_state, flg); flg = (i_flg == 0)
+    ops = [(t[0], t[1], t[2], t[3], t[5], t[4] == 0) for t in batch]
+    res_list = core.get_one_body_green_batch(ops, exct_cut, batch_id=batch_id)
+    assert len(res_list) == len(batch), \
+        "batch {}: got {} results for {} operators".format(batch_id, len(res_list), len(batch))
+    return {_task_key(t): r for t, r in zip(batch, res_list)}
 
 def check_eta(p_common):
     _, T_list, exct, eta, path_to_HPhi, header, output_dir, _, *rest = p_common
@@ -253,7 +321,7 @@ class CalcSpectrumCore:
                 for idx, value in enumerate(spectrum):
                     fw.write("{} {} {} {}\n".format(self.frequencies[idx].real, self.frequencies[idx].imag, value.real, value.imag))
 
-    def _update_modpara(self, exct, ex_state=0, calc_dir="./"):
+    def _update_modpara(self, exct, ex_state=0, calc_dir="./", num_op=1):
         dict_mod={}
         header = []
         with open(os.path.join(self.parent_dir, "modpara.def"), "r") as fr:
@@ -266,6 +334,10 @@ class CalcSpectrumCore:
                 # 'exct' is the loop COUNT (= exct_cut); HPhi reads each E_idx from
                 # the energy file and uses it as the per-state shift internally.
                 dict_mod["SpectrumLoopExct"] = [exct]
+                if num_op > 1:
+                    # HPhi evaluates num_op operator sets (op-inner) reading each
+                    # eigenvector once; set 0 is single_ex.def, sets 1.. are single_ex_<op>.def.
+                    dict_mod["SpectrumNumOp"] = [num_op]
             else:
                 dict_mod["OmegaOrg"] = [self.energy_list[exct], 0]
             if ex_state == 0:
@@ -310,16 +382,19 @@ class CalcSpectrumCore:
                     fw.write("{} {} {} 1.0 0.0\n".format(site_i, sigma_i, ex_state))
                     fw.write("{} {} {} 1.0 0.0\n".format(site_j, sigma_j, ex_state))
 
-    def _run_HPhi(self, exct_cut, ex_state=0, calc_dir="./"):
+    def _run_HPhi(self, exct_cut, ex_state=0, calc_dir="./", num_op=1):
         os.chdir(calc_dir)
         exec_path = self.path_to_HPhi
         if self.internal_loop:
-            # One launch covers all exct_cut eigenstates; HPhi writes
-            # output/<header>_DynamicalGreen_<idx>.dat directly (no per-idx rename).
-            self._update_modpara(exct_cut, ex_state, calc_dir)
+            # One launch covers all exct_cut eigenstates (and all num_op operator sets);
+            # HPhi writes output/<header>_DynamicalGreen_<idx>[_<op>].dat directly.
+            self._update_modpara(exct_cut, ex_state, calc_dir, num_op=num_op)
             input_path = os.path.join(calc_dir, "namelist_ex.def")
             cmd = "{} {} -e {} > std.log".format(self.mpi_prefix, exec_path, input_path).strip()
-            subprocess.call(cmd, shell=True)
+            ret = subprocess.call(cmd, shell=True)
+            if ret != 0:
+                raise RuntimeError(
+                    "HPhi spectrum run failed (exit {}) in {}; see std.log".format(ret, calc_dir))
         else:
             for idx in range(exct_cut):
                 self._update_modpara(idx, ex_state, calc_dir)
@@ -347,6 +422,71 @@ class CalcSpectrumCore:
         for idx, T in enumerate(self.T_list):
             one_body_green[idx] = sign * finite_spectrum_list[T]
         return one_body_green
+
+    def _finite_T_spectrum_multiop(self, calc_dir, num_op):
+        """Boltzmann-sum the per-(idx, op) spectra written by a SpectrumNumOp run.
+
+        Returns (frequencies, {op: {T: spectrum}}). Reads
+        <header>_DynamicalGreen_<idx>_<op>.dat for op in 0..num_op-1 and the same
+        self.exct eigenstates as get_finite_T_spectrum.
+        """
+        spec_dir = os.path.join(calc_dir, self.output_dir)
+        frequencies = None
+        raw = {}  # (op, idx) -> complex spectrum
+        for op in range(num_op):
+            for idx in range(self.exct):
+                # HPhi appends the _<op> suffix only when there is more than one
+                # operator set (useOp = nop>1); a single-operator batch writes _<idx>.dat.
+                if num_op > 1:
+                    name = "{}_DynamicalGreen_{}_{}.dat".format(self.header, idx, op)
+                else:
+                    name = "{}_DynamicalGreen_{}.dat".format(self.header, idx)
+                path = os.path.join(spec_dir, name)
+                d = np.loadtxt(path)
+                raw[(op, idx)] = d[:, 2] + 1J * d[:, 3]
+                if op == 0 and idx == 0:
+                    frequencies = d[:, 0] + 1J * d[:, 1]
+        finite = {op: {} for op in range(num_op)}
+        for T in self.T_list:
+            Z = self._calc_Z(T)
+            weights = [np.exp(-(self.energy_list[idx] - self.ene_min) / T) for idx in range(self.exct)]
+            for op in range(num_op):
+                spectrum = np.zeros_like(raw[(op, 0)])
+                for idx in range(self.exct):
+                    spectrum += weights[idx] * raw[(op, idx)]
+                finite[op][T] = spectrum / Z
+        return frequencies, finite
+
+    def get_one_body_green_batch(self, ops, exct_cut, batch_id=0):
+        """Evaluate a batch of single-excitation operators in ONE HPhi run.
+
+        ops: list of (sitei, sigmai, sitej, sigmaj, ex_state, flg), all sharing the
+        same ex_state and the same Hilbert sector (verified by HPhi at run time).
+        The eigenvector for each eigenstate is read once and reused across all
+        operators (op-inner). Returns a list of one_body_green arrays aligned with ops.
+        """
+        ex_state = ops[0][4]
+        num_op = len(ops)
+        calc_dir = os.path.join(self.parent_dir, "batch_{}".format(batch_id))
+        os.makedirs(calc_dir, exist_ok=True)
+        self.Make_Spectrum_Input(calc_dir)
+        # operator set 0 -> single_ex.def (the namelist SingleExcitation), sets 1.. -> single_ex_<op>.def
+        for op, (si, sgi, sj, sgj, exs, flg) in enumerate(ops):
+            fname = "single_ex.def" if op == 0 else "single_ex_{}.def".format(op)
+            self._make_single_excitation(si, sgi, sj, sgj, file_name=fname,
+                                         ex_state=exs, flg_complex=flg, calc_dir=calc_dir)
+        self._run_HPhi(exct_cut, ex_state, calc_dir, num_op=num_op)
+        frequencies, finite = self._finite_T_spectrum_multiop(calc_dir, num_op)
+        if ex_state == 1:
+            self.frequencies = frequencies
+        sign = 1.0 if ex_state == 1 else -1.0
+        out = []
+        for op in range(num_op):
+            one_body_green = np.zeros((len(self.T_list), self.nomega), dtype=np.complex128)
+            for idx, T in enumerate(self.T_list):
+                one_body_green[idx] = sign * finite[op][T]
+            out.append(one_body_green)
+        return out
 
 
 def test_main():

--- a/src/dcore/interaction.py
+++ b/src/dcore/interaction.py
@@ -164,7 +164,8 @@ def _from_ls_to_j(umat_ls: numpy.ndarray, l: int, order=None):
     assert basis_ls.shape == (dim, 2)
 
     # Transform basis of U-matrix
-    umat_j = numpy.einsum('mi,nj,ijkl,ko,lp', tmat.T.conj(), tmat.T.conj(), umat_ls, tmat, tmat)
+    umat_j = numpy.einsum('mi,nj,ijkl,ko,lp', tmat.T.conj(), tmat.T.conj(), umat_ls, tmat, tmat,
+                          optimize=True)
 
     assert umat_j.shape == (dim, dim, dim, dim)
 

--- a/tests/non-mpi/hphi/cross_check/test_hphi_mpi_split.py
+++ b/tests/non-mpi/hphi/cross_check/test_hphi_mpi_split.py
@@ -1,0 +1,140 @@
+#
+# DCore -- Integrated DMFT software for correlated electrons
+# Copyright (C) 2017 The University of Tokyo
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+Integration test for the HPhi Gf two-level parallelism (needs MPI).
+
+It checks *split invariance*: running each HPhi of the Gf step under
+``mpirun -np 4`` (n_procs_per_hphi = 4, n_inner = 4) must give the same
+self-energy as the plain serial layout (n_procs_per_hphi = 1). The physics is
+identical, only the parallel decomposition of the Gf step differs.
+
+Because it compares two layouts of the *same* computation, a small ``exct`` is
+enough (we are not checking thermal convergence here), which keeps it fast.
+
+Requires three things, otherwise the test is skipped (safe in CI):
+  * DCORE_HPHI_MPI_EXEC : an MPI build of HPhi (used with the launcher),
+  * DCORE_HPHI_EXEC     : a (serial-capable) HPhi for the reference run,
+  * mpirun on PATH.
+"""
+
+import os
+import shutil
+
+import numpy
+import pytest
+
+
+def _exe(env_var):
+    p = os.environ.get(env_var)
+    if p and os.path.isfile(p) and os.access(p, os.X_OK):
+        return p
+    return None
+
+
+HPHI_MPI = _exe("DCORE_HPHI_MPI_EXEC")
+HPHI_SERIAL = _exe("DCORE_HPHI_EXEC") or shutil.which("HPhi")
+MPIRUN = shutil.which("mpirun")
+
+pytestmark = pytest.mark.skipif(
+    not (HPHI_MPI and HPHI_SERIAL and MPIRUN),
+    reason="needs DCORE_HPHI_MPI_EXEC + DCORE_HPHI_EXEC + mpirun",
+)
+
+
+# Complex off-diagonal crystal field: a genuinely anti-symmetric off-diagonal Gf,
+# so the parallel path is exercised on the full reconstruction, not just diagonals.
+_CRYSTAL_FIELD = """\
+# sp o1 o2 re im
+0 0 1 0.3  0.2
+0 1 0 0.3 -0.2
+1 0 1 0.3  0.2
+1 1 0 0.3 -0.2
+"""
+
+_MODEL = """\
+[model]
+seedname = {seed}
+lattice = square
+norb = 2
+nelec = 1.0
+t = -1.0
+kanamori = [(4.0, 0.8, 0.0)]
+nk = 8
+local_potential_matrix = {{0: 'cf.in'}}
+local_potential_factor = 1.0
+
+[mpi]
+command = mpirun -np #
+
+[system]
+T = 0.1
+n_iw = 100
+fix_mu = True
+mu = 0.5
+
+[impurity_solver]
+name = HPhi
+exec_path{{str}} = {exec_path}
+n_bath{{int}} = 0
+exct{{int}} = 4
+n_procs_per_hphi{{int}} = {n_procs_per_hphi}
+
+[control]
+max_step = 1
+sigma_mix = 1.0
+"""
+
+
+def _run(work_dir, seed, exec_path, n_procs_per_hphi, np_total):
+    from dcore.dcore_pre import dcore_pre
+    from dcore.dcore import dcore
+    import h5py
+
+    with open(os.path.join(work_dir, "cf.in"), "w") as f:
+        f.write(_CRYSTAL_FIELD)
+    ini = os.path.join(work_dir, seed + ".ini")
+    with open(ini, "w") as f:
+        f.write(_MODEL.format(seed=seed, exec_path=exec_path,
+                              n_procs_per_hphi=n_procs_per_hphi))
+
+    cwd = os.getcwd()
+    os.chdir(work_dir)
+    try:
+        dcore_pre(ini)
+        dcore(ini, np_total)
+        with h5py.File(seed + ".out.h5", "r") as h:
+            d = h["dmft_out"]["Sigma_iw"]["ite1"]["sh0"]["up"]["data"][()]
+    finally:
+        os.chdir(cwd)
+    return d[..., 0] + 1j * d[..., 1]
+
+
+def test_gf_split_is_invariant(tmp_path):
+    # serial layout (n_inner = 1): the reference
+    sigma_serial = _run(str(tmp_path), "serial_ref", HPHI_SERIAL,
+                        n_procs_per_hphi=1, np_total=1)
+    # two-level layout: each HPhi of the Gf step runs under mpirun -np 4
+    sigma_mpi = _run(str(tmp_path), "mpi_split", HPHI_MPI,
+                     n_procs_per_hphi=4, np_total=4)
+
+    assert sigma_mpi.shape == sigma_serial.shape
+    # genuine off-diagonal, so the parallel path really exercises the reconstruction
+    assert numpy.abs(sigma_serial[:, 0, 1]).max() > 0.1
+    # the parallel decomposition must not change the answer
+    diff = numpy.abs(sigma_mpi - sigma_serial).max()
+    assert diff < 5e-3, f"Gf split changed the self-energy: {diff}"

--- a/tests/non-mpi/hphi/cross_check/test_hphi_multibra_loop.py
+++ b/tests/non-mpi/hphi/cross_check/test_hphi_multibra_loop.py
@@ -1,0 +1,202 @@
+#
+# DCore -- Integrated DMFT software for correlated electrons
+# Copyright (C) 2017 The University of Tokyo
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+HPhi-level golden test for the multi-bra finite-T spectrum loop
+(``SpectrumNumBra`` / Stage-3 bra-column reuse).
+
+When ``SpectrumNumBra = L`` the spectrum calculation solves the resolvent for ONE
+ket A|phi> a single time and projects it onto every bra B_b|phi>, b = 0..L-1
+(Komega's ``nl`` left vectors), writing ``zvo_DynamicalGreen_<idx>_<op>_<b>.dat``.
+Bra set 0 is the namelist ``SingleExcitationBra``; sets 1.. come from
+``single_ex_bra_<b>.def``.  This must be numerically identical to running each
+bra separately with ``SpectrumNumBra = 1`` (the single-bra off-diagonal path,
+writing ``zvo_DynamicalGreen_<idx>.dat``): reusing one ket solve for all bras
+only avoids redundant BiCG solves, it must not change the result.
+
+This is the core enabler that lets the DCore HPhi driver cut the BiCG count for
+the one-body Green's function from n_orb**2 to n_orb.  The test drives HPhi
+directly on a 2-site Hubbard dimer, independent of the DCore driver, and runs
+only when an HPhi executable is available (``DCORE_HPHI_EXEC`` or ``HPhi`` on
+``PATH``).
+"""
+
+import os
+import shutil
+import subprocess
+
+import numpy
+import pytest
+
+
+def _hphi_exec():
+    path = os.environ.get("DCORE_HPHI_EXEC")
+    if path and os.path.isfile(path) and os.access(path, os.X_OK):
+        return path
+    return shutil.which("HPhi")
+
+
+HPHI_EXEC = _hphi_exec()
+
+pytestmark = pytest.mark.skipif(
+    HPHI_EXEC is None,
+    reason="HPhi executable not found; set DCORE_HPHI_EXEC to enable the multi-bra test",
+)
+
+NEXCT = 4  # full Hilbert space of the 2-site, 2Sz=0, nelec=2 Hubbard dimer
+
+_STAN = """\
+L = 2
+model = "Hubbard"
+method = "CG"
+lattice = "chain"
+t = 1.0
+U = 4.0
+2Sz = 0
+nelec = 2
+exct = {nexct}
+EigenVecIO = "out"
+"""
+
+_CALCMOD_SPEC = """\
+CalcType   3
+CalcModel   0
+ReStart   0
+CalcSpec   1
+CalcEigenVec   0
+InitialVecType   0
+InputEigenVec   0
+OutputEigenVec   0
+InputHam   0
+OutputHam   0
+OutputExVec   0
+"""
+
+# single-excitation operator sets (HPhi single_ex format): 5 header lines, the
+# 2nd being "NSingle <n>", then "<site> <spin> <type> <re> <im>" lines.
+# All annihilation (type 0), spin up, so ket and both bras map to the SAME
+# Hilbert sector but give DIFFERENT (diagonal vs off-diagonal) spectra.
+_KET = "=====\nNSingle 1\n=====\n=====\n=====\n0 0 0 1.0 0.0\n"      # c_{0,up}
+_BRA0 = "=====\nNSingle 1\n=====\n=====\n=====\n0 0 0 1.0 0.0\n"     # c_{0,up}  -> diagonal G_00
+_BRA1 = "=====\nNSingle 1\n=====\n=====\n=====\n1 0 0 1.0 0.0\n"     # c_{1,up}  -> off-diagonal G_10
+
+_NAMELIST = """\
+         ModPara  modpara_spec.def
+         LocSpin  locspn.def
+           Trans  trans.def
+    CoulombIntra  coulombintra.def
+         CalcMod  calcmod_spec.def
+     SpectrumVec  zvo_eigenvec
+  SingleExcitation  {ket}
+  SingleExcitationBra  {bra}
+"""
+
+
+def _write(path, content):
+    with open(path, "w") as f:
+        f.write(content)
+
+
+def _make_modpara(work, num_bra):
+    """Spectrum modpara = the eigenvalue modpara + SpectrumLoopExct/SpectrumNumBra."""
+    with open(os.path.join(work, "modpara.def")) as f:
+        lines = [ln for ln in f.readlines() if not ln.startswith("PreCG")]
+    lines += ["SpectrumLoopExct  {}\n".format(NEXCT),
+              "SpectrumNumBra  {}\n".format(num_bra),
+              "PreCG          1\n"]
+    _write(os.path.join(work, "modpara_spec.def"), "".join(lines))
+
+
+def _run_hphi(work, namelist):
+    subprocess.run([HPHI_EXEC, "-e", namelist], cwd=work, check=True,
+                   stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+
+def _green(work, name):
+    return numpy.loadtxt(os.path.join(work, "output", name))
+
+
+def _eigenvalue_run(work):
+    """Standard-mode eigenvalue step -> eigenvectors + zvo_energy.dat + def files."""
+    _write(os.path.join(work, "stan1.in"), _STAN.format(nexct=NEXCT))
+    subprocess.run([HPHI_EXEC, "-s", "stan1.in"], cwd=work, check=True,
+                   stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    assert os.path.exists(os.path.join(work, "output", "zvo_energy.dat"))
+    assert os.path.exists(os.path.join(work, "output", "zvo_eigenvec_0_rank_0.dat"))
+    _write(os.path.join(work, "calcmod_spec.def"), _CALCMOD_SPEC)
+
+
+def test_multibra_loop_matches_per_bra(tmp_path):
+    work = str(tmp_path)
+    _eigenvalue_run(work)
+    _write(os.path.join(work, "single_ex_0.def"), _KET)
+    _write(os.path.join(work, "single_ex_bra_0.def"), _BRA0)
+    _write(os.path.join(work, "single_ex_bra_1.def"), _BRA1)
+
+    # --- combined run: SpectrumNumBra=2, one ket solve -> _<idx>_<op>_<bra>.dat ---
+    # bra set 0 = namelist SingleExcitationBra (= single_ex_bra_0.def);
+    # bra set 1 = single_ex_bra_1.def.  op field is forced on (op=0).
+    _make_modpara(work, 2)
+    _write(os.path.join(work, "namelist_spec.def"),
+           _NAMELIST.format(ket="single_ex_0.def", bra="single_ex_bra_0.def"))
+    _run_hphi(work, "namelist_spec.def")
+    combined = {(i, b): _green(work, "zvo_DynamicalGreen_{}_0_{}.dat".format(i, b))
+                for i in range(NEXCT) for b in (0, 1)}
+
+    # --- reference runs: SpectrumNumBra=1, one launch per bra -> _<idx>.dat ---
+    ref = {}
+    for b, bra in ((0, "single_ex_bra_0.def"), (1, "single_ex_bra_1.def")):
+        _make_modpara(work, 1)
+        _write(os.path.join(work, "namelist_spec.def"),
+               _NAMELIST.format(ket="single_ex_0.def", bra=bra))
+        _run_hphi(work, "namelist_spec.def")
+        for i in range(NEXCT):
+            ref[(i, b)] = _green(work, "zvo_DynamicalGreen_{}.dat".format(i))
+
+    # (sanity) the diagonal (bra 0) and off-diagonal (bra 1) spectra must genuinely
+    # differ, otherwise the bra->slot mapping would not be exercised.
+    bra_spread = numpy.abs(ref[(0, 0)] - ref[(0, 1)]).max()
+    assert bra_spread > 1e-2, f"bras not distinct enough ({bra_spread}); test is vacuous"
+
+    # (main) one-ket-solve multi-bra result == per-bra result, for every (idx, bra).
+    worst = 0.0
+    for key in combined:
+        worst = max(worst, numpy.abs(combined[key] - ref[key]).max())
+    assert worst < 1e-10, f"multi-bra loop differs from per-bra runs: {worst}"
+
+
+def test_multibra_rejects_sector_mismatch(tmp_path):
+    """A bra set in a different Hilbert sector (creation vs annihilation) must be rejected,
+    leaving no partial output behind."""
+    work = str(tmp_path)
+    _eigenvalue_run(work)
+    _write(os.path.join(work, "single_ex_0.def"), _KET)
+    _write(os.path.join(work, "single_ex_bra_0.def"), _BRA0)
+    # bra set 1 = c_{1,up}^dag (creation, type 1) -> opposite sector shift to the ket.
+    _write(os.path.join(work, "single_ex_bra_1.def"),
+           "=====\nNSingle 1\n=====\n=====\n=====\n1 0 1 1.0 0.0\n")
+    _make_modpara(work, 2)
+    _write(os.path.join(work, "namelist_spec.def"),
+           _NAMELIST.format(ket="single_ex_0.def", bra="single_ex_bra_0.def"))
+    for f in os.listdir(os.path.join(work, "output")):
+        if "DynamicalGreen" in f:
+            os.remove(os.path.join(work, "output", f))
+    proc = subprocess.run([HPHI_EXEC, "-e", "namelist_spec.def"], cwd=work,
+                          stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    assert proc.returncode != 0, "HPhi should abort on the mismatched bra set"
+    leftover = [f for f in os.listdir(os.path.join(work, "output")) if "DynamicalGreen" in f]
+    assert not leftover, f"partial output left behind: {leftover}"

--- a/tests/non-mpi/hphi/cross_check/test_hphi_multiop_loop.py
+++ b/tests/non-mpi/hphi/cross_check/test_hphi_multiop_loop.py
@@ -1,0 +1,205 @@
+#
+# DCore -- Integrated DMFT software for correlated electrons
+# Copyright (C) 2017 The University of Tokyo
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+HPhi-level golden test for the multi-operator finite-T spectrum loop
+(``SpectrumNumOp`` / op-inner eigenvector reuse).
+
+When ``SpectrumNumOp = N`` the spectrum calculation reads each eigenvector ONCE
+and, for that eigenstate, builds and solves the spectrum for every operator set
+op = 0 .. N-1 in turn (op-inner), writing ``zvo_DynamicalGreen_<idx>_<op>.dat``.
+This must be numerically identical to running each operator separately with
+``SpectrumNumOp = 1`` (the Stage-1a per-operator path): the batching only avoids
+redundant eigenvector reads, it must not change the result.
+
+The test drives HPhi directly (standard mode for the eigenvalue step, expert mode
+for the spectrum) on a 2-site Hubbard dimer, so it does not depend on the DCore
+HPhi driver and validates the HPhi feature in isolation.  It runs only when an
+HPhi executable is available (``DCORE_HPHI_EXEC`` or ``HPhi`` on ``PATH``).
+"""
+
+import os
+import shutil
+import subprocess
+
+import numpy
+import pytest
+
+
+def _hphi_exec():
+    path = os.environ.get("DCORE_HPHI_EXEC")
+    if path and os.path.isfile(path) and os.access(path, os.X_OK):
+        return path
+    return shutil.which("HPhi")
+
+
+HPHI_EXEC = _hphi_exec()
+
+pytestmark = pytest.mark.skipif(
+    HPHI_EXEC is None,
+    reason="HPhi executable not found; set DCORE_HPHI_EXEC to enable the multi-op test",
+)
+
+NEXCT = 4  # full Hilbert space of the 2-site, 2Sz=0, nelec=2 Hubbard dimer
+
+_STAN = """\
+L = 2
+model = "Hubbard"
+method = "CG"
+lattice = "chain"
+t = 1.0
+U = 4.0
+2Sz = 0
+nelec = 2
+exct = {nexct}
+EigenVecIO = "out"
+"""
+
+_CALCMOD_SPEC = """\
+CalcType   3
+CalcModel   0
+ReStart   0
+CalcSpec   1
+CalcEigenVec   0
+InitialVecType   0
+InputEigenVec   0
+OutputEigenVec   0
+InputHam   0
+OutputHam   0
+OutputExVec   0
+"""
+
+# single-excitation operator sets (HPhi single_ex format): 5 header lines, the
+# 2nd being "NSingle <n>", then "<site> <spin> <type> <re> <im>" lines.
+# op0 = c_{0,up}; op1 = c_{0,up} + c_{1,up}.  Both annihilation (type 0), spin
+# up, so they map to the SAME Hilbert sector but give DIFFERENT spectra.
+_OP0 = "=====\nNSingle 1\n=====\n=====\n=====\n0 0 0 1.0 0.0\n"
+_OP1 = "=====\nNSingle 2\n=====\n=====\n=====\n0 0 0 1.0 0.0\n1 0 0 1.0 0.0\n"
+
+_NAMELIST = """\
+         ModPara  modpara_spec.def
+         LocSpin  locspn.def
+           Trans  trans.def
+    CoulombIntra  coulombintra.def
+         CalcMod  calcmod_spec.def
+     SpectrumVec  zvo_eigenvec
+  SingleExcitation  {single_ex}
+"""
+
+
+def _write(path, content):
+    with open(path, "w") as f:
+        f.write(content)
+
+
+def _make_modpara(work, num_op):
+    """Spectrum modpara = the eigenvalue modpara + SpectrumLoopExct/SpectrumNumOp."""
+    with open(os.path.join(work, "modpara.def")) as f:
+        lines = [ln for ln in f.readlines() if not ln.startswith("PreCG")]
+    lines += ["SpectrumLoopExct  {}\n".format(NEXCT),
+              "SpectrumNumOp  {}\n".format(num_op),
+              "PreCG          1\n"]
+    _write(os.path.join(work, "modpara_spec.def"), "".join(lines))
+
+
+def _run_hphi(work, namelist):
+    subprocess.run([HPHI_EXEC, "-e", namelist], cwd=work, check=True,
+                   stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+
+def _green(work, name):
+    return numpy.loadtxt(os.path.join(work, "output", name))
+
+
+def _eigenvalue_run(work):
+    """Standard-mode eigenvalue step -> eigenvectors + zvo_energy.dat + def files."""
+    _write(os.path.join(work, "stan1.in"), _STAN.format(nexct=NEXCT))
+    subprocess.run([HPHI_EXEC, "-s", "stan1.in"], cwd=work, check=True,
+                   stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    assert os.path.exists(os.path.join(work, "output", "zvo_energy.dat"))
+    assert os.path.exists(os.path.join(work, "output", "zvo_eigenvec_0_rank_0.dat"))
+    _write(os.path.join(work, "calcmod_spec.def"), _CALCMOD_SPEC)
+
+
+def test_multiop_loop_matches_per_operator(tmp_path):
+    work = str(tmp_path)
+    _eigenvalue_run(work)
+    _write(os.path.join(work, "single_ex_0.def"), _OP0)
+    _write(os.path.join(work, "single_ex_1.def"), _OP1)
+
+    # --- combined run: SpectrumNumOp=2, one launch -> _<idx>_<op>.dat ---
+    _make_modpara(work, 2)
+    _write(os.path.join(work, "namelist_spec.def"),
+           _NAMELIST.format(single_ex="single_ex_0.def"))
+    _run_hphi(work, "namelist_spec.def")
+    combined = {(i, op): _green(work, "zvo_DynamicalGreen_{}_{}.dat".format(i, op))
+                for i in range(NEXCT) for op in (0, 1)}
+
+    # --- reference runs: SpectrumNumOp=1, one launch per operator -> _<idx>.dat ---
+    ref = {}
+    for op, single_ex in ((0, "single_ex_0.def"), (1, "single_ex_1.def")):
+        _make_modpara(work, 1)
+        _write(os.path.join(work, "namelist_spec.def"),
+               _NAMELIST.format(single_ex=single_ex))
+        _run_hphi(work, "namelist_spec.def")
+        for i in range(NEXCT):
+            ref[(i, op)] = _green(work, "zvo_DynamicalGreen_{}.dat".format(i))
+
+    # (sanity) the two operators must give genuinely different spectra, otherwise
+    # the op->slot mapping would not be exercised.
+    op_spread = numpy.abs(ref[(0, 0)] - ref[(0, 1)]).max()
+    assert op_spread > 1e-2, f"operators not distinct enough ({op_spread}); test is vacuous"
+
+    # (main) batched op-inner result == per-operator result, for every (idx, op).
+    worst = 0.0
+    for key in combined:
+        worst = max(worst, numpy.abs(combined[key] - ref[key]).max())
+    assert worst < 1e-10, f"multi-op loop differs from per-operator runs: {worst}"
+
+
+def _run_multiop_expect_failure(work, single_ex_1):
+    """Run a SpectrumNumOp=2 launch whose set 1 is invalid; expect a clean abort."""
+    _write(os.path.join(work, "single_ex_0.def"), _OP0)
+    _write(os.path.join(work, "single_ex_1.def"), single_ex_1)
+    _make_modpara(work, 2)
+    _write(os.path.join(work, "namelist_spec.def"),
+           _NAMELIST.format(single_ex="single_ex_0.def"))
+    for f in os.listdir(os.path.join(work, "output")):
+        if "DynamicalGreen" in f:
+            os.remove(os.path.join(work, "output", f))
+    proc = subprocess.run([HPHI_EXEC, "-e", "namelist_spec.def"], cwd=work,
+                          stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    assert proc.returncode != 0, "HPhi should abort on the invalid operator set"
+    # and it must not leave any partial per-state output behind.
+    leftover = [f for f in os.listdir(os.path.join(work, "output")) if "DynamicalGreen" in f]
+    assert not leftover, f"partial output left behind: {leftover}"
+
+
+def test_multiop_rejects_sector_mismatch(tmp_path):
+    """Set 1 in a different Hilbert sector (creation vs annihilation) must be rejected."""
+    work = str(tmp_path)
+    _eigenvalue_run(work)
+    # op0 = c_{0,up} (annihilation, type 0); set 1 = c_{1,up}^dag (creation, type 1).
+    _run_multiop_expect_failure(work, "=====\nNSingle 1\n=====\n=====\n=====\n1 0 1 1.0 0.0\n")
+
+
+def test_multiop_rejects_truncated_operator_file(tmp_path):
+    """A single_ex_<op>.def truncated before its operator line must be rejected."""
+    work = str(tmp_path)
+    _eigenvalue_run(work)
+    # full 5-line header announcing one operator, but the operator line is missing.
+    _run_multiop_expect_failure(work, "=====\nNSingle 1\n=====\n=====\n=====\n")

--- a/tests/non-mpi/hphi/cross_check/test_hphi_vs_scipy_sparse.py
+++ b/tests/non-mpi/hphi/cross_check/test_hphi_vs_scipy_sparse.py
@@ -85,8 +85,9 @@ sigma_mix = 1.0
 """
 
 
-def _run_solver(work_dir, seed, solver_block, extra_model="", aux_files=None):
-    """Run dcore_pre + dcore for one solver and return Sigma_iw as (n_iw, norb, norb)."""
+def _run_solver(work_dir, seed, solver_block, extra_model="", aux_files=None, block="up"):
+    """Run dcore_pre + dcore for one solver and return the Sigma_iw block (the spin block 'up'
+    by default, or the combined 'ud' block for a spin-orbit model)."""
     from dcore.dcore_pre import dcore_pre
     from dcore.dcore import dcore
     import h5py
@@ -106,7 +107,7 @@ def _run_solver(work_dir, seed, solver_block, extra_model="", aux_files=None):
         dcore_pre(ini)
         dcore(ini)
         with h5py.File(seed + ".out.h5", "r") as h:
-            data = h["dmft_out"]["Sigma_iw"]["ite1"]["sh0"]["up"]["data"][()]
+            data = h["dmft_out"]["Sigma_iw"]["ite1"]["sh0"][block]["data"][()]
     finally:
         os.chdir(cwd)
     return data[..., 0] + 1j * data[..., 1]
@@ -223,3 +224,76 @@ def test_hphi_matches_scipy_sparse_offdiagonal(sigma_scipy_offdiag, tmp_path):
     # element (the spurious tail showed up only at high frequency).
     diff = numpy.abs(sigma_hphi - ref).max()
     assert diff < 5e-3, f"HPhi vs scipy/sparse mismatch over full omega_n: {diff}"
+
+
+def test_hphi_braket_ne_only_matches_scipy_sparse(sigma_scipy_offdiag, tmp_path, monkeypatch):
+    """The spin-orbit-capable Ne-only bra/ket route (HubbardNConserved) must reproduce the same
+    off-diagonal self-energy on a 2Sz-conserving model when forced on via
+    ``DCORE_HPHI_FORCE_NE_SECTORS``. This exercises the whole Ne-only machinery -- the
+    HubbardNConserved single-excitation off-diagonal spectrum, both-spin bra/ket per Ne sector,
+    the dNe-only cross-operator sector check, and the Ne-sector recombination -- end to end against
+    the independent scipy/sparse ED reference (the cross-spin blocks it computes are zero here and
+    are dropped from Gimp, so only the same-spin blocks are compared)."""
+    monkeypatch.setenv("DCORE_HPHI_BRAKET", "1")
+    monkeypatch.setenv("DCORE_HPHI_FORCE_NE_SECTORS", "1")
+    solver_block = (
+        "name = HPhi\n"
+        f"exec_path{{str}} = {HPHI_EXEC}\n"
+        "n_bath{int} = 0\n"
+        "exct{int} = 16\n"
+        "np{int} = 1"
+    )
+    sigma_hphi = _run_solver(tmp_path, "hphi_run_ne", solver_block,
+                             extra_model=_OFFDIAG_MODEL, aux_files={"cf.in": _CRYSTAL_FIELD})
+    ref = sigma_scipy_offdiag
+    assert sigma_hphi.shape == ref.shape
+    diff = numpy.abs(sigma_hphi - ref).max()
+    assert diff < 5e-3, f"Ne-only bra/ket vs scipy/sparse mismatch over full omega_n: {diff}"
+
+
+# --- Generalization A: spin-orbit (2Sz NOT conserved) bra/ket via HubbardNConserved Ne sectors ---
+_SO_CRYSTAL_FIELD = """\
+# block i j re im  (combined spin-orbital basis, 2*norb=4; spin-flip = up<->down off-diagonal)
+0 0 2 0.25  0.15
+0 2 0 0.25 -0.15
+0 1 3 0.10 -0.05
+0 3 1 0.10  0.05
+"""
+_SO_MODEL = ("spin_orbit = True\n"
+             "local_potential_matrix = {0: 'cf_so.in'}\n"
+             "local_potential_factor = 1.0")
+
+
+@pytest.fixture(scope="module")
+def sigma_scipy_so(tmp_path_factory):
+    """scipy/sparse spin-orbit reference (spin-flip crystal field) -- the ground truth."""
+    pytest.importorskip("scipy")
+    work_dir = str(tmp_path_factory.mktemp("scipy_sparse_so"))
+    solver_block = "name = scipy/sparse\nn_bath{int} = 0"
+    return _run_solver(work_dir, "scipy_so", solver_block, extra_model=_SO_MODEL,
+                       aux_files={"cf_so.in": _SO_CRYSTAL_FIELD}, block="ud")
+
+
+def test_hphi_braket_spin_orbit_matches_scipy_sparse(sigma_scipy_so, tmp_path, monkeypatch):
+    """Generalization A, end to end: with spin-orbit coupling (2Sz NOT conserved) the bra/ket route
+    sectors by Ne only (HubbardNConserved) and computes the CROSS-spin self-energy too. The full
+    combined-basis Sigma (2*norb x 2*norb) -- including the genuinely non-zero cross-spin blocks
+    from the spin-flip term -- must match the independent scipy/sparse ED reference over the whole
+    Matsubara axis. Exercises: HubbardNConserved single-excitation off-diagonal spectrum, the sz()
+    boundary-sector fix, both-spin bra/ket per Ne sector, and the spin-orbit Dyson self-energy."""
+    monkeypatch.setenv("DCORE_HPHI_BRAKET", "1")  # spin-orbit -> auto Ne-canonical bra/ket
+    solver_block = (
+        "name = HPhi\n"
+        f"exec_path{{str}} = {HPHI_EXEC}\n"
+        "n_bath{int} = 0\n"
+        "exct{int} = 16\n"
+        "np{int} = 1"
+    )
+    sigma_hphi = _run_solver(tmp_path, "hphi_so", solver_block, extra_model=_SO_MODEL,
+                             aux_files={"cf_so.in": _SO_CRYSTAL_FIELD}, block="ud")
+    ref = sigma_scipy_so
+    assert sigma_hphi.shape == ref.shape
+    # the cross-spin block must be genuinely non-zero (spin-flip), else the test is vacuous
+    assert numpy.abs(ref[:, 0, 2]).max() > 0.1
+    diff = numpy.abs(sigma_hphi - ref).max()
+    assert diff < 5e-3, f"spin-orbit bra/ket vs scipy/sparse mismatch over full omega_n: {diff}"

--- a/tests/non-mpi/hphi/cross_check/test_hphi_vs_scipy_sparse.py
+++ b/tests/non-mpi/hphi/cross_check/test_hphi_vs_scipy_sparse.py
@@ -1,0 +1,161 @@
+#
+# DCore -- Integrated DMFT software for correlated electrons
+# Copyright (C) 2017 The University of Tokyo
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+Cross-validation of the HPhi impurity solver against the scipy/sparse solver.
+
+Both are exact-diagonalization (ED) solvers, so for the same impurity model
+they must yield the same self-energy.  This test catches a class of bugs that
+single-solver unit tests cannot, e.g. a wrong off-diagonal Green's-function
+reconstruction *or* an insufficient number of computed eigenstates (``exct``).
+
+Physics being checked (2-orbital Kanamori atom, Hubbard-I / ``n_bath = 0``):
+  * the two orbitals are degenerate, so Sigma must be orbital-symmetric
+    (Sigma[0,0] == Sigma[1,1]) with vanishing off-diagonal (Sigma[0,1] == 0);
+  * the 1-electron ground state is 4-fold degenerate, so HPhi needs
+    ``exct`` large enough to cover the whole low-energy multiplet at finite T
+    (here the full 16-dimensional space) -- otherwise the thermal trace is
+    incomplete and the orbital symmetry is spuriously broken.
+
+The HPhi part runs only when an HPhi executable is available; set the path via
+the ``DCORE_HPHI_EXEC`` environment variable (or have ``HPhi`` on ``PATH``).
+Without it the whole module is skipped, so this is safe in CI.
+"""
+
+import os
+import shutil
+
+import numpy
+import pytest
+
+
+def _hphi_exec():
+    """Resolve an HPhi executable from the environment, else None."""
+    path = os.environ.get("DCORE_HPHI_EXEC")
+    if path and os.path.isfile(path) and os.access(path, os.X_OK):
+        return path
+    return shutil.which("HPhi")
+
+
+HPHI_EXEC = _hphi_exec()
+
+pytestmark = pytest.mark.skipif(
+    HPHI_EXEC is None,
+    reason="HPhi executable not found; set DCORE_HPHI_EXEC to enable the cross-check",
+)
+
+
+# Shared 2-orbital model.  Only the [impurity_solver] block differs between runs.
+_MODEL_TEMPLATE = """\
+[model]
+seedname = {seed}
+lattice = square
+norb = 2
+nelec = 1.0
+t = -1.0
+kanamori = [(4.0, 0.8, 0.0)]
+nk = 8
+
+[system]
+T = 0.1
+n_iw = 500
+fix_mu = True
+mu = 0.5
+
+[impurity_solver]
+{solver_block}
+
+[control]
+max_step = 1
+sigma_mix = 1.0
+"""
+
+
+def _run_solver(work_dir, seed, solver_block):
+    """Run dcore_pre + dcore for one solver and return Sigma_iw as (n_iw, norb, norb)."""
+    from dcore.dcore_pre import dcore_pre
+    from dcore.dcore import dcore
+    import h5py
+
+    ini = os.path.join(work_dir, seed + ".ini")
+    with open(ini, "w") as f:
+        f.write(_MODEL_TEMPLATE.format(seed=seed, solver_block=solver_block))
+
+    cwd = os.getcwd()
+    os.chdir(work_dir)
+    try:
+        dcore_pre(ini)
+        dcore(ini)
+        with h5py.File(seed + ".out.h5", "r") as h:
+            data = h["dmft_out"]["Sigma_iw"]["ite1"]["sh0"]["up"]["data"][()]
+    finally:
+        os.chdir(cwd)
+    return data[..., 0] + 1j * data[..., 1]
+
+
+@pytest.fixture(scope="module")
+def sigma_scipy(tmp_path_factory):
+    """Self-energy from the scipy/sparse ED solver -- the ground-truth reference."""
+    pytest.importorskip("scipy")
+    work_dir = str(tmp_path_factory.mktemp("scipy_sparse"))
+    solver_block = "name = scipy/sparse\nn_bath{int} = 0"
+    return _run_solver(work_dir, "scipy_ref", solver_block)
+
+
+def test_scipy_sparse_is_orbital_symmetric(sigma_scipy):
+    """Sanity check on the ED reference: degenerate orbitals -> symmetric, diagonal Sigma."""
+    n2 = sigma_scipy.shape[0] // 2
+    low = slice(n2 - 50, n2 + 50)
+    diag_asym = numpy.abs(sigma_scipy[low, 0, 0] - sigma_scipy[low, 1, 1]).max()
+    offdiag = numpy.abs(sigma_scipy[:, 0, 1]).max()
+    assert diag_asym < 1e-4, f"reference diagonal not symmetric: {diag_asym}"
+    assert offdiag < 1e-4, f"reference off-diagonal not zero: {offdiag}"
+
+
+def test_hphi_matches_scipy_sparse(sigma_scipy, tmp_path):
+    """
+    HPhi with enough eigenstates must reproduce the scipy/sparse ED self-energy.
+
+    exct = 16 spans the full Hilbert space of the 2-site (2-orbital, n_bath=0)
+    problem, so the finite-T thermal trace is complete and the 4-fold degenerate
+    ground multiplet is fully included.
+    """
+    solver_block = (
+        "name = HPhi\n"
+        f"exec_path{{str}} = {HPHI_EXEC}\n"
+        "n_bath{int} = 0\n"
+        "exct{int} = 16\n"
+        "np{int} = 1"
+    )
+    sigma_hphi = _run_solver(str(tmp_path), "hphi_run", solver_block)
+
+    assert sigma_hphi.shape == sigma_scipy.shape
+
+    n2 = sigma_hphi.shape[0] // 2
+    low = slice(n2 - 50, n2 + 50)
+
+    # (1) HPhi must keep the orbital symmetry it should have (broken when exct=1).
+    diag_asym = numpy.abs(sigma_hphi[low, 0, 0] - sigma_hphi[low, 1, 1]).max()
+    assert diag_asym < 5e-3, f"HPhi diagonal not orbital-symmetric: {diag_asym}"
+
+    # (2) HPhi off-diagonal must vanish for this model.
+    offdiag = numpy.abs(sigma_hphi[:, 0, 1]).max()
+    assert offdiag < 5e-3, f"HPhi spurious off-diagonal: {offdiag}"
+
+    # (3) HPhi diagonal must match the scipy/sparse ED reference.
+    diff = numpy.abs(sigma_hphi[low, 0, 0] - sigma_scipy[low, 0, 0]).max()
+    assert diff < 5e-3, f"HPhi vs scipy/sparse diagonal mismatch: {diff}"

--- a/tests/non-mpi/hphi/cross_check/test_hphi_vs_scipy_sparse.py
+++ b/tests/non-mpi/hphi/cross_check/test_hphi_vs_scipy_sparse.py
@@ -69,7 +69,7 @@ nelec = 1.0
 t = -1.0
 kanamori = [(4.0, 0.8, 0.0)]
 nk = 8
-
+{extra_model}
 [system]
 T = 0.1
 n_iw = 500
@@ -85,15 +85,20 @@ sigma_mix = 1.0
 """
 
 
-def _run_solver(work_dir, seed, solver_block):
+def _run_solver(work_dir, seed, solver_block, extra_model="", aux_files=None):
     """Run dcore_pre + dcore for one solver and return Sigma_iw as (n_iw, norb, norb)."""
     from dcore.dcore_pre import dcore_pre
     from dcore.dcore import dcore
     import h5py
 
+    for name, content in (aux_files or {}).items():
+        with open(os.path.join(work_dir, name), "w") as f:
+            f.write(content)
+
     ini = os.path.join(work_dir, seed + ".ini")
     with open(ini, "w") as f:
-        f.write(_MODEL_TEMPLATE.format(seed=seed, solver_block=solver_block))
+        f.write(_MODEL_TEMPLATE.format(seed=seed, solver_block=solver_block,
+                                       extra_model=extra_model))
 
     cwd = os.getcwd()
     os.chdir(work_dir)
@@ -159,3 +164,62 @@ def test_hphi_matches_scipy_sparse(sigma_scipy, tmp_path):
     # (3) HPhi diagonal must match the scipy/sparse ED reference.
     diff = numpy.abs(sigma_hphi[low, 0, 0] - sigma_scipy[low, 0, 0]).max()
     assert diff < 5e-3, f"HPhi vs scipy/sparse diagonal mismatch: {diff}"
+
+
+# Hermitian complex off-diagonal crystal field mixing orbitals 0 and 1 (both spins).
+# The imaginary part makes the off-diagonal Green's function genuinely
+# anti-symmetric (G_01 != G_10), which exercises the A = c_i + i c_j excitation
+# of the HPhi reconstruction across the *whole* Matsubara axis.
+_CRYSTAL_FIELD = """\
+# sp o1 o2 re im
+0 0 1 0.3  0.2
+0 1 0 0.3 -0.2
+1 0 1 0.3  0.2
+1 1 0 0.3 -0.2
+"""
+_OFFDIAG_MODEL = "local_potential_matrix = {0: 'cf.in'}\nlocal_potential_factor = 1.0"
+
+
+@pytest.fixture(scope="module")
+def sigma_scipy_offdiag(tmp_path_factory):
+    """scipy/sparse reference for the model with a complex off-diagonal crystal field."""
+    pytest.importorskip("scipy")
+    work_dir = str(tmp_path_factory.mktemp("scipy_sparse_offdiag"))
+    solver_block = "name = scipy/sparse\nn_bath{int} = 0"
+    return _run_solver(work_dir, "scipy_ref_od", solver_block,
+                       extra_model=_OFFDIAG_MODEL, aux_files={"cf.in": _CRYSTAL_FIELD})
+
+
+def test_hphi_matches_scipy_sparse_offdiagonal(sigma_scipy_offdiag, tmp_path):
+    """
+    Regression test for the off-diagonal Green's-function reconstruction.
+
+    With a complex off-diagonal crystal field the self-energy has a genuine,
+    anti-symmetric off-diagonal component.  A wrong conjugation of the
+    ``c_i + i c_j`` excitation used to give the off-diagonal self-energy a
+    spurious term that *diverged linearly* with the Matsubara frequency while
+    staying small at low frequency -- hence the comparison spans the entire
+    Matsubara axis, not just iw_0.
+    """
+    solver_block = (
+        "name = HPhi\n"
+        f"exec_path{{str}} = {HPHI_EXEC}\n"
+        "n_bath{int} = 0\n"
+        "exct{int} = 16\n"
+        "np{int} = 1"
+    )
+    sigma_hphi = _run_solver(tmp_path, "hphi_run_od", solver_block,
+                             extra_model=_OFFDIAG_MODEL, aux_files={"cf.in": _CRYSTAL_FIELD})
+
+    ref = sigma_scipy_offdiag
+    assert sigma_hphi.shape == ref.shape
+
+    # The off-diagonal must be genuinely non-zero and anti-symmetric, otherwise
+    # the test would not exercise the A = c_i + i c_j reconstruction at all.
+    assert numpy.abs(ref[:, 0, 1]).max() > 0.1
+    assert numpy.abs(ref[:, 0, 1] - ref[:, 1, 0]).max() > 0.05
+
+    # HPhi must match scipy/sparse over the WHOLE Matsubara axis and every matrix
+    # element (the spurious tail showed up only at high frequency).
+    diff = numpy.abs(sigma_hphi - ref).max()
+    assert diff < 5e-3, f"HPhi vs scipy/sparse mismatch over full omega_n: {diff}"

--- a/tests/non-mpi/hphi/test_batch_routing.py
+++ b/tests/non-mpi/hphi/test_batch_routing.py
@@ -29,7 +29,39 @@ import itertools
 
 import numpy as np
 
-from dcore.impurity_solvers.hphi_spectrum import _group_tasks_by_sector, _task_key
+from dcore.impurity_solvers.hphi_spectrum import (
+    _group_tasks_by_sector, _task_key, _task_valid_in_sector)
+
+
+def _task(sitei, sigmai, sitej, sigmaj, ex_state):
+    # idx_flg is irrelevant to _task_valid_in_sector; p_common omitted (task[:6] used)
+    return (sitei, sigmai, sitej, sigmaj, 0, ex_state)
+
+
+def test_task_valid_in_sector_skips_only_exactly_zero_contributions():
+    n_site = 2
+    # sigma: 0 = up, 1 = down. ex_state: 0 = annihilation, 1 = creation.
+    # --- annihilation needs the spin occupied; creation needs a free slot ---
+    # empty up sector (n_up=0): up-annihilation is zero, up-creation is allowed
+    assert not _task_valid_in_sector(_task(0, 0, 0, 0, 0), n_up=0, n_down=1, n_site=n_site)
+    assert _task_valid_in_sector(_task(0, 0, 0, 0, 1), n_up=0, n_down=1, n_site=n_site)
+    # full up sector (n_up=n_site): up-creation is zero, up-annihilation is allowed
+    assert not _task_valid_in_sector(_task(0, 0, 0, 0, 1), n_up=n_site, n_down=1, n_site=n_site)
+    assert _task_valid_in_sector(_task(0, 0, 0, 0, 0), n_up=n_site, n_down=1, n_site=n_site)
+    # same logic for the down spin (sigma=1) uses n_down
+    assert not _task_valid_in_sector(_task(0, 1, 0, 1, 0), n_up=1, n_down=0, n_site=n_site)
+    assert not _task_valid_in_sector(_task(0, 1, 0, 1, 1), n_up=1, n_down=n_site, n_site=n_site)
+    # interior occupancy: both channels valid
+    assert _task_valid_in_sector(_task(0, 0, 1, 0, 0), n_up=1, n_down=1, n_site=n_site)
+    assert _task_valid_in_sector(_task(0, 0, 1, 0, 1), n_up=1, n_down=1, n_site=n_site)
+
+
+def test_task_valid_in_sector_rejects_all_cross_spin():
+    # cross-spin off-diagonal (sigma_i != sigma_j) is zero by spin conservation -> always skipped
+    for ex_state in (0, 1):
+        for n_up, n_down in [(1, 1), (2, 0), (0, 2)]:
+            assert not _task_valid_in_sector(_task(0, 0, 1, 1, ex_state), n_up, n_down, 2)
+            assert not _task_valid_in_sector(_task(0, 1, 1, 0, ex_state), n_up, n_down, 2)
 
 
 def _gen_tasks(n_site):

--- a/tests/non-mpi/hphi/test_batch_routing.py
+++ b/tests/non-mpi/hphi/test_batch_routing.py
@@ -1,0 +1,99 @@
+#
+# DCore -- Integrated DMFT software for correlated electrons
+# Copyright (C) 2017 The University of Tokyo
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+Pure-Python checks for the HPhi sector-batching routing used by
+``calc_one_body_green_core_parallel`` in internal-loop mode.
+
+These exercise the new grouping / reassembly logic without needing an HPhi
+executable: that each task lands in exactly one batch, every same-spin batch is
+sector-consistent (one (ex_state, sigma)), cross-spin off-diagonal operators are
+singletons, and the task-order reassembly maps every result back correctly.
+"""
+
+import itertools
+
+import numpy as np
+
+from dcore.impurity_solvers.hphi_spectrum import _group_tasks_by_sector, _task_key
+
+
+def _gen_tasks(n_site):
+    """Reproduce the task list of calc_one_body_green_core_parallel.gen_p()."""
+    n_sigma = 2
+    n_excitation = 2
+    # p_common contains T_list (a list) -> the full task tuple is unhashable, which
+    # is exactly why _task_key drops it; keep it here to mirror the real tasks.
+    p_common = (n_site, [1.0], 4, 1e-4, "HPhi", "zvo", "./output", 4)
+
+    def comp(site, sigma):
+        return site * n_sigma + sigma
+
+    tasks = []
+    for si, sgi in itertools.product(range(n_site), range(n_sigma)):
+        for sj, sgj in itertools.product(range(n_site), range(n_sigma)):
+            if comp(si, sgi) > comp(sj, sgj):
+                continue
+            for idx_flg in range(2):
+                for ex_state in range(n_excitation):
+                    if comp(si, sgi) == comp(sj, sgj) and idx_flg == 1:
+                        continue
+                    tasks.append((si, sgi, sj, sgj, idx_flg, ex_state, p_common))
+    return tasks
+
+
+def test_group_tasks_cover_each_task_exactly_once():
+    tasks = _gen_tasks(2)
+    batches = _group_tasks_by_sector(tasks)
+    flat = [t for b in batches for t in b]
+    assert len(flat) == len(tasks)
+    assert {_task_key(t) for t in flat} == {_task_key(t) for t in tasks}
+    # no task duplicated across or within batches
+    assert len({_task_key(t) for t in flat}) == len(flat)
+
+
+def test_batches_are_sector_consistent():
+    tasks = _gen_tasks(2)
+    for b in _group_tasks_by_sector(_gen_tasks(2)):
+        sector_keys = set()
+        for (si, sgi, sj, sgj, idx_flg, ex_state, _) in b:
+            if sgi == sgj:
+                sector_keys.add((ex_state, sgi))
+            else:
+                # cross-spin operators mix Sz -> must be alone in their launch
+                assert len(b) == 1, "cross-spin operator was batched with others"
+        # a same-spin batch carries exactly one (ex_state, sigma)
+        assert len(sector_keys) <= 1
+
+
+def test_task_order_reassembly_round_trips():
+    tasks = _gen_tasks(2)
+    batches = _group_tasks_by_sector(tasks)
+
+    def synth(t):
+        return np.array(_task_key(t), dtype=float)
+
+    # emulate calc_one_body_green_batch: each batch returns {task_key: result}
+    result_map = {}
+    for b in batches:
+        for t in b:
+            result_map[_task_key(t)] = synth(t)
+
+    assert len(result_map) == len(tasks)
+    results = [result_map[_task_key(t)] for t in tasks]
+    for t, r in zip(tasks, results):
+        assert np.array_equal(r, synth(t))

--- a/tests/non-mpi/hphi/test_braket_routing.py
+++ b/tests/non-mpi/hphi/test_braket_routing.py
@@ -1,0 +1,111 @@
+#
+# DCore -- Integrated DMFT software for correlated electrons
+# Copyright (C) 2017 The University of Tokyo
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+Pure-Python checks for the Stage-3 direct bra/ket launch enumeration
+(``_braket_sector_jobs``), CI-safe (no HPhi executable needed).
+
+Each launch is one (ex_state, spin) sector with kets = bras = all same-spin
+sites; cross-spin operators are never emitted, and a canonical occupancy drops
+the (ex_state, spin) sectors whose excited state vanishes.
+"""
+
+import os
+
+import numpy as np
+import pytest
+
+from dcore.impurity_solvers.hphi_spectrum import (
+    _braket_sector_jobs, CalcSpectrumCore, calc_one_body_green_core_parallel)
+
+
+def test_grand_canonical_runs_every_exstate_and_spin():
+    n_site = 3
+    jobs = _braket_sector_jobs(n_site, None)
+    # 2 ex_state x 2 spin = 4 launches.
+    assert len(jobs) == 4
+    seen = set()
+    for ex_state, ket_ops, bra_ops in jobs:
+        assert ket_ops == bra_ops, "ket and bra operator lists must match"
+        spins = {sg for (_, sg) in ket_ops}
+        assert len(spins) == 1, "a launch is a single spin sector"
+        sigma = spins.pop()
+        # all sites of that spin are present
+        assert [s for (s, _) in ket_ops] == list(range(n_site))
+        seen.add((ex_state, sigma))
+    assert seen == {(e, s) for e in (0, 1) for s in (0, 1)}
+
+
+def test_no_cross_spin_operators():
+    for occ in (None, (1, 1, 2), (2, 0, 2)):
+        for ex_state, ket_ops, bra_ops in _braket_sector_jobs(2, occ):
+            sigmas = {sg for (_, sg) in ket_ops} | {sg for (_, sg) in bra_ops}
+            assert len(sigmas) == 1, "cross-spin operators must never be batched"
+
+
+def test_canonical_drops_empty_and_full_spin_sectors():
+    n_site = 2
+    # sector with up fully empty (n_up=0) and down half-filled (n_down=1)
+    jobs = _braket_sector_jobs(n_site, (0, 1, n_site))
+    got = {(ex_state, ket_ops[0][1]) for ex_state, ket_ops, _ in jobs}
+    # up (sigma 0): annihilation (ex 0) invalid (empty); creation (ex 1) valid
+    assert (0, 0) not in got
+    assert (1, 0) in got
+    # down (sigma 1, n_down=1): both annihilation and creation valid (0 < 1 < 2)
+    assert (0, 1) in got and (1, 1) in got
+
+    # full up sector (n_up = n_site): creation invalid, annihilation valid
+    jobs_full = _braket_sector_jobs(n_site, (n_site, 1, n_site))
+    got_full = {(ex_state, ket_ops[0][1]) for ex_state, ket_ops, _ in jobs_full}
+    assert (1, 0) not in got_full   # up creation on a full spin vanishes
+    assert (0, 0) in got_full       # up annihilation valid
+
+
+def test_braket_reader_handles_single_site_unsuffixed_files(tmp_path):
+    """n_site == 1 gives num_op == num_bra == 1, so HPhi writes the unsuffixed
+    <header>_DynamicalGreen_<idx>.dat; the braket reader must accept that layout."""
+    core = CalcSpectrumCore([1.0], 2, 1e-4, header="zvo", output_dir="output")
+    core.energy_list = [0.0, 0.5]
+    core.ene_min = 0.0
+    spec_dir = os.path.join(str(tmp_path), "output")
+    os.makedirs(spec_dir)
+    # 3 frequencies; columns: re(w) im(w) re(G) im(G). idx encodes the value so we can check it.
+    for idx in range(2):
+        rows = np.array([[w, 0.0, float(idx) + w, -float(idx)] for w in range(3)])
+        np.savetxt(os.path.join(spec_dir, "zvo_DynamicalGreen_{}.dat".format(idx)), rows)
+    freqs, finite = core._finite_T_spectrum_braket(str(tmp_path), num_op=1, num_bra=1)
+    assert (0, 0, 1.0) in finite          # the (op=0, bra=0) diagonal element exists
+    assert finite[(0, 0, 1.0)].shape == (3,)
+    assert len(freqs) == 3
+
+
+def _p_common(n_site):
+    return (n_site, [1.0], 1, 1e-4, "./HPhi", "zvo", "./output", 1)
+
+
+def test_braket_rejects_grand_canonical(monkeypatch):
+    """DCORE_HPHI_BRAKET=1 with no sector (grand canonical) must fail cleanly, not run."""
+    monkeypatch.setenv("DCORE_HPHI_BRAKET", "1")
+    with pytest.raises(RuntimeError, match="canonical sector"):
+        calc_one_body_green_core_parallel(_p_common(2), max_workers=1, sector_occupancy=None)
+
+
+def test_braket_rejects_zero_site(monkeypatch):
+    """n_site == 0 raises the stable ValueError on the bra/ket path too (not StopIteration)."""
+    monkeypatch.setenv("DCORE_HPHI_BRAKET", "1")
+    with pytest.raises(ValueError, match="n_site must be >= 1"):
+        calc_one_body_green_core_parallel(_p_common(0), max_workers=1, sector_occupancy=(0, 0, 0))

--- a/tests/non-mpi/hphi/test_braket_routing.py
+++ b/tests/non-mpi/hphi/test_braket_routing.py
@@ -30,7 +30,8 @@ import numpy as np
 import pytest
 
 from dcore.impurity_solvers.hphi_spectrum import (
-    _braket_sector_jobs, CalcSpectrumCore, calc_one_body_green_core_parallel)
+    _braket_sector_jobs, _braket_ne_sector_jobs, _braket_store_op, _braket_assemble,
+    _braket_one_body_green, CalcSpectrumCore, calc_one_body_green_core_parallel)
 
 
 def test_grand_canonical_runs_every_exstate_and_spin():
@@ -93,6 +94,97 @@ def test_braket_reader_handles_single_site_unsuffixed_files(tmp_path):
     assert len(freqs) == 3
 
 
+def test_ne_sector_jobs_use_both_spins_and_include_cross_spin():
+    """The Ne-only (spin-orbit) route batches BOTH spins per launch, so cross-spin operator
+    pairs are present (unlike the same-spin (Ne, 2Sz) route)."""
+    n_site = 2
+    jobs = _braket_ne_sector_jobs(n_site, ne=2)  # interior Ne: both ex_state valid
+    assert len(jobs) == 2
+    for ex_state, ket_ops, bra_ops in jobs:
+        assert ket_ops == bra_ops
+        # all 2*n_site spin-orbitals present, both spins
+        assert sorted(ket_ops) == [(s, sg) for s in range(n_site) for sg in (0, 1)]
+        assert {sg for (_, sg) in ket_ops} == {0, 1}
+
+
+def test_ne_sector_jobs_drop_empty_and_full():
+    n_site = 2
+    n_so = 2 * n_site
+    # vacuum (Ne=0): only creation (ex_state 1)
+    assert [e for e, _, _ in _braket_ne_sector_jobs(n_site, 0)] == [1]
+    # full (Ne = 2*n_site): only annihilation (ex_state 0)
+    assert [e for e, _, _ in _braket_ne_sector_jobs(n_site, n_so)] == [0]
+    # interior: both
+    assert sorted(e for e, _, _ in _braket_ne_sector_jobs(n_site, 2)) == [0, 1]
+
+
+def test_ne_sector_jobs_reject_out_of_range_ne():
+    with pytest.raises(ValueError, match=r"ne must be in"):
+        _braket_ne_sector_jobs(2, ne=-1)
+    with pytest.raises(ValueError, match=r"ne must be in"):
+        _braket_ne_sector_jobs(2, ne=5)  # 2*n_site = 4
+    # n_site = 0: only the empty (Ne=0) sector; creation valid (Ne <= 2*n_site-1 = -1 is False),
+    # annihilation invalid -> no jobs.
+    assert _braket_ne_sector_jobs(0, ne=0) == []
+
+
+def test_braket_store_op_convention():
+    # g = G_{bra, ket}. Annihilation (ex 0): stored at [ket][bra]. Creation (ex 1): transposed [bra][ket].
+    bra, ket = (0, 0), (1, 0)  # same spin, off-diagonal
+    assert _braket_store_op(bra, ket, 0) == (ket, bra)   # (1,0),(0,0)
+    assert _braket_store_op(bra, ket, 1) == (bra, ket)   # (0,0),(1,0)  -> transpose
+    # diagonal: both channels store at the same place
+    d = (0, 0)
+    assert _braket_store_op(d, d, 0) == _braket_store_op(d, d, 1) == (d, d)
+    # cross-spin uses the identical convention
+    bra_x, ket_x = (0, 0), (0, 1)
+    assert _braket_store_op(bra_x, ket_x, 0) == (ket_x, bra_x)
+    assert _braket_store_op(bra_x, ket_x, 1) == (bra_x, ket_x)
+
+
+def test_braket_assemble_places_same_and_cross_spin(monkeypatch):
+    """Mocked accumulation: feed _braket_assemble per-launch {(row_op,col_op): g} dicts (the
+    storage keys _braket_store_op produces) for both an annihilation and a creation launch over
+    BOTH spins, and check every (i,si,j,sj) slot -- including cross-spin -- lands where expected.
+    g carries a unique tag per (bra, ket, ex_state) so mis-routing would be caught."""
+    n_site = 2
+    ops = [(s, sg) for s in range(n_site) for sg in range(2)]  # all 4 spin-orbitals
+    # tag(bra, ket, ex) -> a distinct (n_T=1, n_omega=1) complex "spectrum"
+    def tag(bra, ket, ex):
+        code = (bra[0] * 2 + bra[1]) * 10 + (ket[0] * 2 + ket[1]) + 100 * ex
+        return np.array([[code + 0j]])
+
+    results = []
+    expected = {}  # (row_op, col_op) -> summed g
+    for ex in (0, 1):
+        res = {}
+        for ket in ops:
+            for bra in ops:
+                g = tag(bra, ket, ex)
+                key = _braket_store_op(bra, ket, ex)  # storage index
+                res[key] = g
+                expected[key] = expected.get(key, np.zeros((1, 1), dtype=complex)) + g
+        results.append(res)
+
+    obg = _braket_assemble(results, n_site)
+    assert obg.shape == (n_site, 2, n_site, 2, 1, 1)
+    # every stored slot matches the summed expectation, incl. cross-spin (si != sj)
+    saw_cross = False
+    for (row_op, col_op), val in expected.items():
+        (ri, rsg), (ci, csg) = row_op, col_op
+        assert obg[ri][rsg][ci][csg][0, 0] == val[0, 0]
+        if rsg != csg:
+            saw_cross = True
+    assert saw_cross, "cross-spin slots must be exercised"
+
+
+def test_braket_one_body_green_rejects_ne_only_with_occupancy():
+    # ne_only and sector_occupancy are mutually exclusive; the guard runs before any HPhi launch.
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        _braket_one_body_green(_p_common(2), max_workers=1,
+                               sector_occupancy=(1, 1, 2), ne_only=2)
+
+
 def _p_common(n_site):
     return (n_site, [1.0], 1, 1e-4, "./HPhi", "zvo", "./output", 1)
 
@@ -100,7 +192,7 @@ def _p_common(n_site):
 def test_braket_rejects_grand_canonical(monkeypatch):
     """DCORE_HPHI_BRAKET=1 with no sector (grand canonical) must fail cleanly, not run."""
     monkeypatch.setenv("DCORE_HPHI_BRAKET", "1")
-    with pytest.raises(RuntimeError, match="canonical sector"):
+    with pytest.raises(RuntimeError, match="grand-canonical bra/ket route is unsupported"):
         calc_one_body_green_core_parallel(_p_common(2), max_workers=1, sector_occupancy=None)
 
 

--- a/tests/non-mpi/hphi/test_excitation_def.py
+++ b/tests/non-mpi/hphi/test_excitation_def.py
@@ -1,0 +1,82 @@
+#
+# DCore -- Integrated DMFT software for correlated electrons
+# Copyright (C) 2017 The University of Tokyo
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+Unit tests for the HPhi off-diagonal excitation definition (no HPhi binary).
+
+These guard the fix to the complex excitation A = c_i + i c_j: the creation
+channel (ex_state == 1) must use the conjugate operator A^dag = c_i^dag - i c_j^dag,
+i.e. the imaginary coefficient of c_j flips sign between the annihilation and
+creation channels. Getting this wrong gives the anti-symmetric (imaginary) part
+of the off-diagonal Green's function a divergent high-frequency tail.
+"""
+
+import os
+
+import pytest
+
+from dcore.impurity_solvers.hphi_spectrum import CalcSpectrumCore
+
+
+def _parse_single_ex(path):
+    """Return the operator rows (site, spin, op, re, im) from a single_ex.def file."""
+    rows = []
+    with open(path) as f:
+        for line in f:
+            tok = line.split()
+            if len(tok) == 5:  # site spin op re im
+                rows.append((int(tok[0]), int(tok[1]), int(tok[2]),
+                             float(tok[3]), float(tok[4])))
+    return rows
+
+
+def _write_offdiag_excitation(tmp_path, ex_state):
+    core = CalcSpectrumCore([0.1], 1, 1e-4, path_to_HPhi="HPhi")
+    # off-diagonal pair: (site 0, spin 0) and (site 1, spin 0) -> composites 0 != 2
+    core._make_single_excitation(0, 0, 1, 0, file_name="single_ex.def",
+                                 ex_state=ex_state, flg_complex=True,
+                                 calc_dir=str(tmp_path))
+    return _parse_single_ex(os.path.join(str(tmp_path), "single_ex.def"))
+
+
+def test_annihilation_channel_uses_plus_i(tmp_path):
+    rows = _write_offdiag_excitation(tmp_path, ex_state=0)
+    assert len(rows) == 2
+    # c_i with coefficient 1, c_j with coefficient +i
+    assert rows[0][3:] == (1.0, 0.0)
+    assert rows[1][3:] == (0.0, 1.0)
+    assert all(op == 0 for _, _, op, _, _ in rows)
+
+
+def test_creation_channel_uses_minus_i(tmp_path):
+    rows = _write_offdiag_excitation(tmp_path, ex_state=1)
+    assert len(rows) == 2
+    # A^dag: c_i^dag with coefficient 1, c_j^dag with coefficient -i
+    assert rows[0][3:] == (1.0, 0.0)
+    assert rows[1][3:] == (0.0, -1.0)
+    assert all(op == 1 for _, _, op, _, _ in rows)
+
+
+@pytest.mark.parametrize("ex_state", [0, 1])
+def test_real_combination_is_unaffected(tmp_path, ex_state):
+    # flg_complex=False -> B = c_i + c_j, both coefficients real and independent of channel
+    core = CalcSpectrumCore([0.1], 1, 1e-4, path_to_HPhi="HPhi")
+    core._make_single_excitation(0, 0, 1, 0, file_name="b.def",
+                                 ex_state=ex_state, flg_complex=False,
+                                 calc_dir=str(tmp_path))
+    rows = _parse_single_ex(os.path.join(str(tmp_path), "b.def"))
+    assert [r[3:] for r in rows] == [(1.0, 0.0), (1.0, 0.0)]

--- a/tests/non-mpi/hphi/test_exct_warning.py
+++ b/tests/non-mpi/hphi/test_exct_warning.py
@@ -1,0 +1,86 @@
+#
+# DCore -- Integrated DMFT software for correlated electrons
+# Copyright (C) 2017 The University of Tokyo
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+Unit tests for the HPhi 'exct too small' warning (pure Python, no HPhi binary).
+"""
+
+import numpy
+import pytest
+
+from dcore.impurity_solvers.hphi import (
+    read_eigenenergies,
+    warn_if_exct_truncates_thermal_trace,
+)
+
+# Exact 2-orbital Kanamori atomic spectrum (eps=-0.5, U=4, U'=0.8, J=0): 16 states.
+KANAMORI_SPECTRUM = numpy.array(
+    [-0.5] * 4 + [-0.2] * 4 + [0.0] + [3.0] * 2 + [4.1] * 4 + [9.2]
+)
+EXCT_MAX = 16
+BETA = 10.0
+
+
+def _write_energy_file(path, energies):
+    with open(path, "w") as f:
+        for i, e in enumerate(numpy.sort(energies)):
+            f.write(f"State {i}\n  Energy  {e:.16f} \n  Doublon  0.0 \n  Sz  0.0 \n")
+
+
+def test_read_eigenenergies(tmp_path):
+    fn = str(tmp_path / "zvo_energy.dat")
+    _write_energy_file(fn, KANAMORI_SPECTRUM[:5])
+    e = read_eigenenergies(fn)
+    assert e.size == 5
+    assert numpy.isclose(e.min(), -0.5)
+
+
+def _warns(tmp_path, exct):
+    fn = str(tmp_path / "zvo_energy.dat")
+    _write_energy_file(fn, KANAMORI_SPECTRUM[: min(exct, EXCT_MAX)])
+    return fn
+
+
+@pytest.mark.parametrize("exct", [1, 4, 9])
+def test_warns_when_exct_too_small(tmp_path, capsys, exct):
+    fn = _warns(tmp_path, exct)
+    warn_if_exct_truncates_thermal_trace(fn, BETA, exct, EXCT_MAX)
+    err = capsys.readouterr().err
+    assert "exct" in err and "may be too small" in err
+
+
+@pytest.mark.parametrize("exct", [11, 16])
+def test_silent_when_exct_sufficient(tmp_path, capsys, exct):
+    fn = _warns(tmp_path, exct)
+    warn_if_exct_truncates_thermal_trace(fn, BETA, exct, EXCT_MAX)
+    err = capsys.readouterr().err
+    assert err == ""
+
+
+def test_no_warning_when_full_space(tmp_path, capsys):
+    # exct == exct_max must never warn, even if the last state has weight.
+    fn = _warns(tmp_path, EXCT_MAX)
+    warn_if_exct_truncates_thermal_trace(fn, BETA, EXCT_MAX, EXCT_MAX)
+    assert capsys.readouterr().err == ""
+
+
+def test_missing_file_does_not_raise(tmp_path, capsys):
+    # A missing energy file must not abort the solver.
+    warn_if_exct_truncates_thermal_trace(
+        str(tmp_path / "does_not_exist.dat"), BETA, 1, EXCT_MAX
+    )
+    assert capsys.readouterr().err == ""

--- a/tests/non-mpi/hphi/test_exct_warning.py
+++ b/tests/non-mpi/hphi/test_exct_warning.py
@@ -78,6 +78,20 @@ def test_no_warning_when_full_space(tmp_path, capsys):
     assert capsys.readouterr().err == ""
 
 
+def test_conservative_warning_for_near_degenerate_then_gap(tmp_path, capsys):
+    # Retained states are near-degenerate at the bottom, with a large gap above.
+    # w_last (~1) is an UPPER BOUND on the omitted weight, so the criterion warns
+    # conservatively even though the true omitted tail (at energy 10) is negligible.
+    # This documents the intended behavior: the warning means "truncation cannot be
+    # ruled out", not "truncation definitely occurred".
+    fn = str(tmp_path / "zvo_energy.dat")
+    _write_energy_file(fn, numpy.array([0.0, 1e-4]))  # exct=2, full space larger
+    warn_if_exct_truncates_thermal_trace(fn, BETA, 2, EXCT_MAX)
+    err = capsys.readouterr().err
+    assert "may be too small" in err
+    assert "upper bound" in err  # message is framed as a conservative bound
+
+
 def test_missing_file_does_not_raise(tmp_path, capsys):
     # A missing energy file must not abort the solver.
     warn_if_exct_truncates_thermal_trace(

--- a/tests/non-mpi/hphi/test_gf_parallel_layout.py
+++ b/tests/non-mpi/hphi/test_gf_parallel_layout.py
@@ -72,3 +72,47 @@ def test_prefix_uses_last_token_of_command():
     # the launcher template is preserved, only the rank count is replaced.
     _, _, prefix = gf_parallel_layout("mpiexec --bind-to core -n 16", 16, 4)
     assert prefix == "mpiexec --bind-to core -n 4"
+
+
+def test_non_divisible_total_floors_outer():
+    # np_total not divisible by n_inner: n_outer = floor(18/4) = 4 (2 ranks idle).
+    n_inner, n_outer, prefix = gf_parallel_layout(CMD, 18, 4)
+    assert n_inner == 4
+    assert n_outer == 4
+    assert prefix == "mpirun -np 4"
+
+
+def test_mpi_prefix_propagates_into_hphi_command(tmp_path, monkeypatch):
+    """A 9-element p_common must carry mpi_prefix all the way into the HPhi command."""
+    from dcore.impurity_solvers import hphi_spectrum as hs
+
+    calls = []
+    monkeypatch.setattr(hs.subprocess, "call", lambda cmd, shell: calls.append(cmd) or 0)
+
+    _, _, prefix = gf_parallel_layout(CMD, 16, 4)  # "mpirun -np 4"
+    core = hs.CalcSpectrumCore([0.1], 1, 1e-4, path_to_HPhi="HPhi_bin", mpi_prefix=prefix)
+    monkeypatch.setattr(core, "_update_modpara", lambda *a, **k: None)
+    core._run_HPhi(exct_cut=1, ex_state=0, calc_dir=str(tmp_path))
+
+    hphi_cmd = calls[0]  # first call is the HPhi run (second is the mv)
+    assert hphi_cmd.startswith("mpirun -np 4 ")
+    assert "HPhi_bin -e" in hphi_cmd
+
+
+def test_serial_command_has_no_mpirun(tmp_path, monkeypatch):
+    """Default (serial) layout must invoke HPhi directly, with no launcher prefix."""
+    from dcore.impurity_solvers import hphi_spectrum as hs
+
+    calls = []
+    monkeypatch.setattr(hs.subprocess, "call", lambda cmd, shell: calls.append(cmd) or 0)
+
+    core = hs.CalcSpectrumCore([0.1], 1, 1e-4, path_to_HPhi="HPhi_bin", mpi_prefix="")
+    monkeypatch.setattr(core, "_update_modpara", lambda *a, **k: None)
+    core._run_HPhi(exct_cut=1, ex_state=0, calc_dir=str(tmp_path))
+
+    hphi_cmd = calls[0]
+    # no launcher prefix, and no leading whitespace (empty prefix is stripped);
+    # path_to_HPhi is stored as an absolute path, so match the basename + " -e".
+    assert not hphi_cmd.startswith("mpirun")
+    assert hphi_cmd == hphi_cmd.strip()
+    assert "HPhi_bin -e" in hphi_cmd

--- a/tests/non-mpi/hphi/test_gf_parallel_layout.py
+++ b/tests/non-mpi/hphi/test_gf_parallel_layout.py
@@ -1,0 +1,74 @@
+#
+# DCore -- Integrated DMFT software for correlated electrons
+# Copyright (C) 2017 The University of Tokyo
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+Unit tests for the HPhi Gf two-level parallel layout (pure Python, no HPhi).
+"""
+
+import pytest
+
+from dcore.impurity_solvers.hphi import gf_parallel_layout
+
+CMD = "mpirun -np 16"
+
+
+def test_default_is_serial_backward_compatible():
+    # n_procs_per_hphi=1 reproduces the previous behaviour: serial HPhi, np workers.
+    n_inner, n_outer, prefix = gf_parallel_layout(CMD, 16, 1)
+    assert (n_inner, n_outer, prefix) == (1, 16, "")
+
+
+def test_unknown_np_falls_back_to_serial():
+    n_inner, n_outer, prefix = gf_parallel_layout(CMD, None, 4)
+    assert (n_inner, n_outer, prefix) == (1, None, "")
+
+
+@pytest.mark.parametrize(
+    "np_total,req,exp_inner,exp_outer",
+    [
+        (16, 4, 4, 4),    # clean split
+        (16, 16, 16, 1),  # all ranks to one HPhi
+        (64, 4, 4, 16),
+    ],
+)
+def test_clean_power_of_four_split(np_total, req, exp_inner, exp_outer):
+    n_inner, n_outer, prefix = gf_parallel_layout(CMD, np_total, req)
+    assert n_inner == exp_inner
+    assert n_outer == exp_outer
+    assert prefix == f"mpirun -np {exp_inner}"
+
+
+def test_non_power_of_four_is_rounded_down():
+    # 8 is not a power of four -> rounded down to 4.
+    n_inner, n_outer, prefix = gf_parallel_layout(CMD, 16, 8)
+    assert n_inner == 4
+    assert n_outer == 4
+    assert prefix == "mpirun -np 4"
+
+
+def test_inner_cannot_exceed_total():
+    # request more inner ranks than available -> clamped to np_total.
+    n_inner, n_outer, prefix = gf_parallel_layout(CMD, 4, 16)
+    assert n_inner == 4
+    assert n_outer == 1
+    assert prefix == "mpirun -np 4"
+
+
+def test_prefix_uses_last_token_of_command():
+    # the launcher template is preserved, only the rank count is replaced.
+    _, _, prefix = gf_parallel_layout("mpiexec --bind-to core -n 16", 16, 4)
+    assert prefix == "mpiexec --bind-to core -n 4"

--- a/tests/non-mpi/hphi/test_gf_parallel_layout.py
+++ b/tests/non-mpi/hphi/test_gf_parallel_layout.py
@@ -27,14 +27,23 @@ CMD = "mpirun -np 16"
 
 
 def test_default_is_serial_backward_compatible():
-    # n_procs_per_hphi=1 reproduces the previous behaviour: serial HPhi, np workers.
-    n_inner, n_outer, prefix = gf_parallel_layout(CMD, 16, 1)
-    assert (n_inner, n_outer, prefix) == (1, 16, "")
+    # n_procs_per_hphi=1: single-rank HPhi, np concurrent runs.
+    n_inner, n_outer, eigen_cmd, prefix = gf_parallel_layout(CMD, 16, 1)
+    assert (n_inner, n_outer) == (1, 16)
+    assert eigen_cmd == "mpirun -np 1"   # eigenvalue step also single-rank
+    assert prefix == ""                  # Gf runs go bare when single-rank
 
 
-def test_unknown_np_falls_back_to_serial():
-    n_inner, n_outer, prefix = gf_parallel_layout(CMD, None, 4)
-    assert (n_inner, n_outer, prefix) == (1, None, "")
+def test_unparseable_np_keeps_rank_invariant_and_serializes():
+    # When the rank count is not the last token, both phases must still use the
+    # SAME launcher (matching eigenvector ranks) and the Gf step must not run
+    # concurrently (n_outer = 1), otherwise a multi-rank launcher would write
+    # distributed eigenvectors the bare Gf runs cannot read.
+    for cmd in ("mpirun -np 16 --bind-to core", "srun --ntasks 16 ./prog"):
+        n_inner, n_outer, eigen_cmd, prefix = gf_parallel_layout(cmd, None, 4)
+        assert n_outer == 1                 # no concurrency when unparseable
+        assert eigen_cmd == cmd             # eigenvalue uses the given launcher
+        assert prefix == cmd                # Gf uses the SAME launcher (ranks match)
 
 
 @pytest.mark.parametrize(
@@ -46,40 +55,55 @@ def test_unknown_np_falls_back_to_serial():
     ],
 )
 def test_clean_power_of_four_split(np_total, req, exp_inner, exp_outer):
-    n_inner, n_outer, prefix = gf_parallel_layout(CMD, np_total, req)
+    n_inner, n_outer, eigen_cmd, prefix = gf_parallel_layout(CMD, np_total, req)
     assert n_inner == exp_inner
     assert n_outer == exp_outer
+    assert eigen_cmd == f"mpirun -np {exp_inner}"
     assert prefix == f"mpirun -np {exp_inner}"
+
+
+def test_eigenvalue_and_gf_use_the_same_rank_count():
+    # The crucial invariant: the eigenvalue step and each Gf run use the SAME
+    # number of ranks, so the MPI-distributed eigenvectors can be read back.
+    for np_total, req in [(16, 1), (16, 4), (8, 4), (64, 16)]:
+        n_inner, _, eigen_cmd, prefix = gf_parallel_layout(CMD, np_total, req)
+        assert eigen_cmd.endswith(f" {n_inner}")            # eigenvalue ranks
+        if n_inner == 1:
+            assert prefix == ""                             # Gf bare = 1 rank
+        else:
+            assert prefix == eigen_cmd                      # Gf ranks == eigen ranks
 
 
 def test_non_power_of_four_is_rounded_down():
     # 8 is not a power of four -> rounded down to 4.
-    n_inner, n_outer, prefix = gf_parallel_layout(CMD, 16, 8)
+    n_inner, n_outer, eigen_cmd, prefix = gf_parallel_layout(CMD, 16, 8)
     assert n_inner == 4
     assert n_outer == 4
+    assert eigen_cmd == "mpirun -np 4"
     assert prefix == "mpirun -np 4"
 
 
 def test_inner_cannot_exceed_total():
     # request more inner ranks than available -> clamped to np_total.
-    n_inner, n_outer, prefix = gf_parallel_layout(CMD, 4, 16)
+    n_inner, n_outer, eigen_cmd, prefix = gf_parallel_layout(CMD, 4, 16)
     assert n_inner == 4
     assert n_outer == 1
-    assert prefix == "mpirun -np 4"
+    assert eigen_cmd == "mpirun -np 4"
 
 
 def test_prefix_uses_last_token_of_command():
     # the launcher template is preserved, only the rank count is replaced.
-    _, _, prefix = gf_parallel_layout("mpiexec --bind-to core -n 16", 16, 4)
+    _, _, eigen_cmd, prefix = gf_parallel_layout("mpiexec --bind-to core -n 16", 16, 4)
+    assert eigen_cmd == "mpiexec --bind-to core -n 4"
     assert prefix == "mpiexec --bind-to core -n 4"
 
 
 def test_non_divisible_total_floors_outer():
     # np_total not divisible by n_inner: n_outer = floor(18/4) = 4 (2 ranks idle).
-    n_inner, n_outer, prefix = gf_parallel_layout(CMD, 18, 4)
+    n_inner, n_outer, eigen_cmd, prefix = gf_parallel_layout(CMD, 18, 4)
     assert n_inner == 4
     assert n_outer == 4
-    assert prefix == "mpirun -np 4"
+    assert eigen_cmd == "mpirun -np 4"
 
 
 def test_mpi_prefix_propagates_into_hphi_command(tmp_path, monkeypatch):
@@ -89,7 +113,7 @@ def test_mpi_prefix_propagates_into_hphi_command(tmp_path, monkeypatch):
     calls = []
     monkeypatch.setattr(hs.subprocess, "call", lambda cmd, shell: calls.append(cmd) or 0)
 
-    _, _, prefix = gf_parallel_layout(CMD, 16, 4)  # "mpirun -np 4"
+    _, _, _, prefix = gf_parallel_layout(CMD, 16, 4)  # "mpirun -np 4"
     core = hs.CalcSpectrumCore([0.1], 1, 1e-4, path_to_HPhi="HPhi_bin", mpi_prefix=prefix)
     monkeypatch.setattr(core, "_update_modpara", lambda *a, **k: None)
     core._run_HPhi(exct_cut=1, ex_state=0, calc_dir=str(tmp_path))

--- a/tests/non-mpi/hphi/test_ne_sectors.py
+++ b/tests/non-mpi/hphi/test_ne_sectors.py
@@ -1,0 +1,61 @@
+#
+# DCore -- Integrated DMFT software for correlated electrons
+# Copyright (C) 2017 The University of Tokyo
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+CI-safe checks for ``enumerate_ne_sectors`` -- the Ne-only (2Sz-free) sector
+decomposition used by the spin-orbit-capable direct bra/ket path
+(HubbardNConserved). Pure counting; no HPhi executable needed.
+"""
+
+from math import comb
+
+import pytest
+
+from dcore.impurity_solvers.hphi import enumerate_ne_sectors, enumerate_particle_sectors
+
+
+@pytest.mark.parametrize("n_site", [1, 2, 3, 4])
+def test_ne_sectors_partition_the_full_fock_space(n_site):
+    sectors = enumerate_ne_sectors(n_site)
+    # one sector per Ne = 0 .. 2*n_site
+    assert [s['Ne'] for s in sectors] == list(range(2 * n_site + 1))
+    # dimensions sum to the full grand-canonical space
+    assert sum(s['dim'] for s in sectors) == 4 ** n_site
+    # each Ne sector dimension is C(2*n_site, Ne)
+    for s in sectors:
+        assert s['dim'] == comb(2 * n_site, s['Ne'])
+
+
+@pytest.mark.parametrize("n_site", [1, 2, 3, 4])
+def test_ne_sector_is_union_of_2sz_sectors(n_site):
+    """An Ne-only sector merges all (Ne, 2Sz) sectors of the same Ne, so its dimension
+    equals the sum of the corresponding (Ne, 2Sz) sector dimensions."""
+    fine = enumerate_particle_sectors(n_site)
+    fine_dim_by_ne = {}
+    for s in fine:
+        fine_dim_by_ne[s['Ne']] = fine_dim_by_ne.get(s['Ne'], 0) + s['dim']
+    for s in enumerate_ne_sectors(n_site):
+        assert s['dim'] == fine_dim_by_ne[s['Ne']]
+
+
+def test_n_site_zero_is_the_single_vacuum_sector():
+    assert enumerate_ne_sectors(0) == [{'Ne': 0, 'dim': 1}]
+
+
+def test_negative_n_site_rejected():
+    with pytest.raises(ValueError, match="non-negative"):
+        enumerate_ne_sectors(-1)

--- a/tests/non-mpi/hphi/test_ne_sectors.py
+++ b/tests/non-mpi/hphi/test_ne_sectors.py
@@ -25,7 +25,9 @@ from math import comb
 
 import pytest
 
-from dcore.impurity_solvers.hphi import enumerate_ne_sectors, enumerate_particle_sectors
+from dcore.impurity_solvers.hphi import (
+    enumerate_ne_sectors, enumerate_particle_sectors, ne_initial_sectors)
+from dcore.impurity_solvers.hphi_spectrum import _braket_ne_sector_jobs
 
 
 @pytest.mark.parametrize("n_site", [1, 2, 3, 4])
@@ -50,6 +52,35 @@ def test_ne_sector_is_union_of_2sz_sectors(n_site):
         fine_dim_by_ne[s['Ne']] = fine_dim_by_ne.get(s['Ne'], 0) + s['dim']
     for s in enumerate_ne_sectors(n_site):
         assert s['dim'] == fine_dim_by_ne[s['Ne']]
+
+
+@pytest.mark.parametrize("n_site", [1, 2, 3])
+def test_ne_only_route_drops_exactly_the_two_boundary_initial_sectors(n_site):
+    """The spin-orbit (HubbardNConserved) bra/ket route cannot run Ne=0 (HPhi rejects Ncond=0)
+    nor Ne=2*n_site (an sz() Hilbert-construction edge case) as thermally occupied INITIAL
+    sectors. Lock the documented guarantee by exercising the *production* boundary filter
+    ``ne_initial_sectors`` (not a local restatement): it drops exactly those two and keeps every
+    interior sector."""
+    n_so = 2 * n_site
+    exct = 4 ** n_site  # large enough that the exct/dim gate keeps every non-empty sector
+    kept, dropped = ne_initial_sectors(n_site, exct)
+    assert dropped == [0, n_so]
+    assert [s['Ne'] for s in kept] == list(range(1, n_so))  # every interior sector retained
+
+
+@pytest.mark.parametrize("n_site", [1, 2, 3])
+def test_interior_sectors_still_reach_the_boundary_excited_spaces(n_site):
+    """Although Ne=0 / Ne=2*n_site are not run as initial sectors, the retained interior sectors
+    still reach those boundary EXCITED spaces through their Ne+-1 transitions: Ne=1 annihilates
+    into Ne=0 (ex_state 0), and Ne=2*n_site-1 creates into Ne=2*n_site (ex_state 1). This is why
+    the boundary states are not simply absent from the spectrum."""
+    n_so = 2 * n_site
+    # Ne=1: annihilation (ex_state 0) reaches the Ne=0 boundary excited space
+    ex_lo = [ex for (ex, _ket, _bra) in _braket_ne_sector_jobs(n_site, 1)]
+    assert 0 in ex_lo
+    # Ne=2*n_site-1: creation (ex_state 1) reaches the Ne=2*n_site boundary excited space
+    ex_hi = [ex for (ex, _ket, _bra) in _braket_ne_sector_jobs(n_site, n_so - 1)]
+    assert 1 in ex_hi
 
 
 def test_n_site_zero_is_the_single_vacuum_sector():

--- a/tests/non-mpi/hphi/test_particle_sectors.py
+++ b/tests/non-mpi/hphi/test_particle_sectors.py
@@ -1,0 +1,66 @@
+#
+# DCore -- Integrated DMFT software for correlated electrons
+# Copyright (C) 2017 The University of Tokyo
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""Unit tests for the (Ne, 2Sz) particle-number sector enumeration used by the
+canonical (sector-resolved) HPhi spectrum path."""
+
+from math import comb
+
+import pytest
+
+from dcore.impurity_solvers.hphi import enumerate_particle_sectors
+
+
+@pytest.mark.parametrize("n_site", [1, 2, 3, 4])
+def test_sectors_partition_the_grand_canonical_space(n_site):
+    sectors = enumerate_particle_sectors(n_site)
+    # the sector dimensions must add up to the full grand-canonical space 4**n_site
+    assert sum(s['dim'] for s in sectors) == 4 ** n_site
+    # (Ne, 2Sz) labels are unique, and there are exactly (n_site+1)**2 of them
+    labels = [(s['Ne'], s['two_Sz']) for s in sectors]
+    assert len(labels) == len(set(labels)) == (n_site + 1) ** 2
+    # the list is returned sorted by (Ne, 2Sz) -- the per-sector loop relies on this order
+    assert labels == sorted(labels)
+
+
+def test_n_site_zero_is_the_single_vacuum_sector():
+    assert enumerate_particle_sectors(0) == [
+        {'Ne': 0, 'two_Sz': 0, 'n_up': 0, 'n_down': 0, 'dim': 1}
+    ]
+
+
+def test_negative_n_site_is_rejected():
+    with pytest.raises(ValueError):
+        enumerate_particle_sectors(-1)
+
+
+def test_sector_quantum_numbers_are_consistent():
+    for s in enumerate_particle_sectors(3):
+        assert s['n_up'] + s['n_down'] == s['Ne']
+        assert s['n_up'] - s['n_down'] == s['two_Sz']
+        assert 0 <= s['n_up'] <= 3 and 0 <= s['n_down'] <= 3
+        assert s['dim'] == comb(3, s['n_up']) * comb(3, s['n_down'])
+
+
+def test_half_filled_sz0_is_the_largest_sector():
+    # for EVEN n_site the (Ne = n_site, 2Sz = 0) sector is the largest (half filling, Sz=0);
+    # for odd n_site, Ne and 2Sz must share parity so 2Sz=0 is not allowed at Ne=n_site.
+    n_site = 4
+    sectors = enumerate_particle_sectors(n_site)
+    largest = max(sectors, key=lambda s: s['dim'])
+    assert largest['Ne'] == n_site
+    assert largest['two_Sz'] == 0

--- a/tests/non-mpi/hphi/test_reconstruction.py
+++ b/tests/non-mpi/hphi/test_reconstruction.py
@@ -1,0 +1,183 @@
+#
+# DCore -- Integrated DMFT software for correlated electrons
+# Copyright (C) 2017 The University of Tokyo
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+import os
+import importlib.util
+import itertools
+
+import numpy as np
+
+# Load hphi_spectrum.py directly by file path. The module only depends on numpy,
+# so the test does not require the optional impurity-solver backends
+# (dcorelib/TRIQS) that the package __init__ would otherwise pull in.
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_MODULE_PATH = os.path.normpath(
+    os.path.join(_HERE, "..", "..", "..", "src", "dcore", "impurity_solvers", "hphi_spectrum.py"))
+_spec = importlib.util.spec_from_file_location("hphi_spectrum", _MODULE_PATH)
+hphi_spectrum = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(hphi_spectrum)
+calc_one_body_green = hphi_spectrum.calc_one_body_green
+
+
+def _composite(site, sigma, n_sigma=2):
+    return site * n_sigma + sigma
+
+
+def _build_core(G, n_site, n_sigma=2):
+    """Synthesize the HPhi excitation 'core' tensor (upper triangle only) for a
+    target Green's-function matrix G, following the reconstruction convention:
+
+        B = c_i + c_j    ->  <<B|B+>> = G_ii + G_jj + G_ij + G_ji    (idx=1)
+        A = c_i + i c_j  ->  <<A|A+>> = G_ii + G_jj + i(G_ji - G_ij)  (idx=0)
+
+    The lower triangle and the diagonal idx=1 channel are left as zeros, exactly
+    as the reduced parallel driver (`calc_one_body_green_core_parallel`) produces
+    them.
+    """
+    n_flg, n_excitation = 2, 2
+    n_T, n_omega = G.shape[2], G.shape[3]
+    core = np.zeros(
+        (n_site, n_sigma, n_site, n_sigma, n_flg, n_excitation, n_T, n_omega),
+        dtype=np.complex128)
+    for si, sgi, sj, sgj in itertools.product(
+            range(n_site), range(n_sigma), range(n_site), range(n_sigma)):
+        a, b = _composite(si, sgi, n_sigma), _composite(sj, sgj, n_sigma)
+        if a > b:
+            continue  # lower triangle is not computed by the reduced driver
+        if a == b:
+            core[si, sgi, sj, sgj, 0, 0] = G[a, a]  # diagonal uses idx=0 only
+            continue
+        diag = G[a, a] + G[b, b]
+        core[si, sgi, sj, sgj, 1, 0] = diag + G[a, b] + G[b, a]
+        core[si, sgi, sj, sgj, 0, 0] = diag + 1j * (G[b, a] - G[a, b])
+    return core
+
+
+def test_offdiagonal_reconstruction_fills_both_triangles():
+    """G_ij AND the transposed G_ji must be recovered, even though the lower
+    triangle is never computed (regression test for the dead-store bug)."""
+    n_site, n_sigma, n_T, n_omega = 3, 2, 1, 4
+    N = n_site * n_sigma
+    rng = np.random.RandomState(2)
+    G = rng.rand(N, N, n_T, n_omega) + 1j * rng.rand(N, N, n_T, n_omega)
+
+    out = calc_one_body_green(_build_core(G, n_site, n_sigma))
+
+    for si, sgi, sj, sgj in itertools.product(
+            range(n_site), range(n_sigma), range(n_site), range(n_sigma)):
+        a, b = _composite(si, sgi, n_sigma), _composite(sj, sgj, n_sigma)
+        if a == b:
+            continue
+        assert np.allclose(out[si, sgi, sj, sgj], G[a, b], atol=1e-12), \
+            "off-diagonal mismatch at (%d,%d,%d,%d)" % (si, sgi, sj, sgj)
+
+
+def test_diagonal_reconstruction():
+    n_site, n_sigma, n_T, n_omega = 2, 2, 1, 3
+    N = n_site * n_sigma
+    rng = np.random.RandomState(5)
+    G = rng.rand(N, N, n_T, n_omega) + 1j * rng.rand(N, N, n_T, n_omega)
+
+    out = calc_one_body_green(_build_core(G, n_site, n_sigma))
+
+    for si, sgi in itertools.product(range(n_site), range(n_sigma)):
+        a = _composite(si, sgi, n_sigma)
+        assert np.allclose(out[si, sgi, si, sgi], G[a, a], atol=1e-12)
+
+
+class _SerialExecutor:
+    """Drop-in stand-in for ProcessPoolExecutor that runs map() in-process, so
+    the monkeypatched worker is actually used (no subprocess / pickling)."""
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+    def map(self, fn, iterable):
+        return [fn(x) for x in iterable]
+
+
+def test_parallel_driver_prunes_tasks_and_reconstructs(monkeypatch):
+    """Drive calc_one_body_green_core_parallel end-to-end with a mocked HPhi
+    worker: assert only the upper triangle is scheduled (diagonal idx=1 skipped)
+    and the assembled Green's function matches the target."""
+    import concurrent.futures
+    import shutil
+
+    n_site, n_sigma, n_T, n_omega = 3, 2, 1, 4
+    N = n_site * n_sigma
+    rng = np.random.RandomState(7)
+    G = rng.rand(N, N, n_T, n_omega) + 1j * rng.rand(N, N, n_T, n_omega)
+
+    scheduled = []
+
+    def fake_worker(task):
+        sitei, sigmai, sitej, sigmaj, idx, ex_state, _p = task
+        scheduled.append((sitei, sigmai, sitej, sigmaj, idx, ex_state))
+        a = _composite(sitei, sigmai, n_sigma)
+        b = _composite(sitej, sigmaj, n_sigma)
+        out = np.zeros((n_T, n_omega), dtype=np.complex128)
+        if a == b:
+            if idx == 0 and ex_state == 0:
+                out[:] = G[a, a]
+            return out
+        if ex_state == 0:
+            diag = G[a, a] + G[b, b]
+            if idx == 1:
+                out[:] = diag + G[a, b] + G[b, a]
+            else:
+                out[:] = diag + 1j * (G[b, a] - G[a, b])
+        return out
+
+    monkeypatch.setattr(hphi_spectrum, "check_eta", lambda p_common: None)
+    monkeypatch.setattr(hphi_spectrum, "calc_one_body_green_core", fake_worker)
+    monkeypatch.setattr(concurrent.futures, "ProcessPoolExecutor", _SerialExecutor)
+    monkeypatch.setattr(shutil, "rmtree", lambda *a, **k: None)
+
+    p_common = (n_site, [1.0], 1, 1e-4, "./HPhi", "zvo", "./output", 1)
+    out = hphi_spectrum.calc_one_body_green_core_parallel(p_common, max_workers=1)
+
+    # Pruning: no lower-triangle pairs, and no diagonal idx==1 tasks.
+    for sitei, sigmai, sitej, sigmaj, idx, ex_state in scheduled:
+        a = _composite(sitei, sigmai, n_sigma)
+        b = _composite(sitej, sigmaj, n_sigma)
+        assert a <= b, "lower-triangle task scheduled"
+        if a == b:
+            assert idx == 0, "diagonal idx==1 task should be skipped"
+
+    # Reconstruction over the full off-diagonal block (including the never-computed
+    # lower triangle).
+    for si, sgi, sj, sgj in itertools.product(
+            range(n_site), range(n_sigma), range(n_site), range(n_sigma)):
+        a, b = _composite(si, sgi, n_sigma), _composite(sj, sgj, n_sigma)
+        if a == b:
+            continue
+        assert np.allclose(out[si, sgi, sj, sgj], G[a, b], atol=1e-12)
+
+
+def test_parallel_driver_rejects_empty_tasks(monkeypatch):
+    monkeypatch.setattr(hphi_spectrum, "check_eta", lambda p_common: None)
+    p_common = (0, [1.0], 1, 1e-4, "./HPhi", "zvo", "./output", 1)
+    try:
+        hphi_spectrum.calc_one_body_green_core_parallel(p_common, max_workers=1)
+    except ValueError:
+        return
+    raise AssertionError("expected ValueError for n_site == 0")


### PR DESCRIPTION
## Summary

Improves the **HPhi** impurity solver's finite-temperature one-body Green's function: a correctness fix for the off-diagonal components, substantial speedups (sector batching, two-level parallelism, internal eigenstate loop, direct bra/ket projection), a particle-number-resolved canonical path, and a spin-orbit-capable route — all cross-validated against the independent `scipy/sparse` ED solver.

## Highlights

**Correctness**
- Fix the off-diagonal G reconstruction (the `c_i + i·c_j` excitation was mis-conjugated) — the diagonal-only result was already correct; off-diagonal blocks now match `scipy/sparse` ED.
- Warn when `exct` is too small to capture the thermal trace at the requested `T`.

**Performance** (all opt-in via `DCORE_HPHI_*` env vars; default path unchanged)
- Batch the one-body Gf operators by Hilbert sector so the eigenvector solve is reused across operators (`SpectrumNumOp` internal loop).
- Two-level (`n_inner × n_outer`) MPI parallelism for the Gf step, with the eigenvalue and Gf steps pinned to the same rank count (split-invariance tested).
- Direct **bra/ket** projection: one ket BiCG solve projected onto `n_orb` bras, cutting the shifted-BiCG count from `n_orb²` to `n_orb` (`SpectrumNumBra`).

**New capabilities**
- Particle-number sector-resolved (canonical) Green's-function path: thermal `(Ne, 2Sz)` sector selection.
- Spin-orbit-capable bra/ket Gf via Ne-only **HubbardNConserved** sectors — reproduces the full `2·norb × 2·norb` self-energy including non-zero cross-spin blocks (validated to ~1e-4 vs `scipy/sparse` with a spin-flip crystal field).

**Tests & docs**
- HPhi vs `scipy/sparse` ED cross-validation test; golden checks for the `SpectrumNumOp` / `SpectrumNumBra` finite-T loops; sector-enumeration and reconstruction unit tests (CI-safe, no external solver needed for the unit ones).
- New HPhi impurity-solver doc page + an accurate ohtaka (ISSP System B) parallel-run recipe.

## Dependency

The bra/ket and spin-orbit paths exercise HPhi spectrum features upstreamed separately — **HPhi PR #254** (`SpectrumNumBra`) and the stacked **HubbardNConserved off-diagonal** PR. They are gated behind `DCORE_HPHI_*` env vars, so this PR is safe to merge ahead of an HPhi release; those code paths simply require a sufficiently new HPhi build at runtime. The always-on off-diagonal correctness fix has no such dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
