### PR TITLE
Make DCore compatible with NumPy 2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,11 +41,15 @@ setup(
 
     python_requires='>=3.8, <4',
     install_requires=[
-        'numpy<2',
-        'scipy>=1.4',
+        # NumPy 2 requires Python >= 3.9, so keep the old pins for Python 3.8.
+        'numpy<2; python_version<"3.9"',
+        'numpy<3; python_version>="3.9"',  # NumPy 2 validated; cap the major version
+        'scipy>=1.4; python_version<"3.9"',
+        'scipy>=1.13; python_version>="3.9"',  # scipy>=1.13 supports NumPy 2
         # h5py 2.10.0 has a bug.
         # Import h5py imports mpi4py automatically.
-        'h5py!=2.10.0',
+        'h5py!=2.10.0; python_version<"3.9"',
+        'h5py>=3.11; python_version>="3.9"',  # h5py>=3.11 supports NumPy 2
         'toml>=0.10',
         'dcorelib>=0.9.7',
         'sympy',

--- a/src/dcore/sumkdft_opt.py
+++ b/src/dcore/sumkdft_opt.py
@@ -385,11 +385,15 @@ class SumkDFT_opt(SumkDFT):
                     n_orb = self.n_orbitals[ik, ind]
                     projmat = self.proj_mat[ik, ind, icrsh, 0:dim, 0:n_orb]
                     for i in range(dim):
-                        index = numpy.where(projmat[i] == 1)
-                        if len(index) != 1:
+                        # Require exactly one matching orbital (a one-hot row);
+                        # otherwise proj_mat is not a clean 0/1 permutation and the
+                        # fancy-index path does not apply, so fall back by returning
+                        # None. Using matches[0] also avoids the numpy>=2 error from
+                        # assigning a length-1 array to a scalar element.
+                        matches = numpy.where(projmat[i] == 1)[0]
+                        if len(matches) != 1:
                             return None
-                        else:
-                            proj_index[ik, ind, icrsh, i] = index[0]
+                        proj_index[ik, ind, icrsh, i] = matches[0]
 
         return proj_index
 

--- a/src/dcore/symmetrizer.py
+++ b/src/dcore/symmetrizer.py
@@ -1,5 +1,4 @@
 import numpy
-from numpy.core.numeric import identity
 from scipy.linalg import expm
 from ._dispatcher import BlockGf
 


### PR DESCRIPTION
## Summary
Two code-level NumPy 2 incompatibilities are fixed:
- `symmetrizer.py` imported `identity` from the private `numpy.core.numeric` (renamed to `numpy._core` in NumPy 2). The import was unused (the code calls `numpy.identity`), so it is removed.
- `SumkDFT_opt.make_proj_index()` assigned a length-1 array (`numpy.where(...)[0]`) to a scalar element, which NumPy 2 rejects. It now extracts the scalar via `matches = numpy.where(projmat[i] == 1)[0]` and requires exactly one match (the previous `len(index) != 1` test was on the `where()` tuple, so it never triggered; multi-match rows used to crash instead of falling back).

`setup.py`: relax the `numpy<2` pin via environment markers — on Python >= 3.9, NumPy 2 is allowed together with `scipy>=1.13` and `h5py>=3.11` (their first NumPy-2-supporting releases), capped at `numpy<3`. Python 3.8 keeps `numpy<2` because NumPy 2 requires Python >= 3.9.

## Verification
End-to-end with the TRIQS-compat (dcorelib 0.9.7) backend on **both numpy 1.26.4 and numpy 2.5.0**: `tests/non-mpi` passes (16 passed; HPhi-binary tests excluded), including the wannier90 DMFT tests that exercise `make_proj_index` and the symmetrizer.

## Out of scope
`make_proj_index()` does not fully validate that projector rows are a clean 0/1 permutation (non-binary values, cross-row column uniqueness). This is pre-existing and unrelated to NumPy 2; this PR only makes the existing behavior NumPy-2-safe and slightly more robust (multi-match rows now fall back instead of crashing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)