### PR TITLE
Fix broken packaging: pin dcorelib<1 and drop dangling dcore_gk script

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,9 @@ setup(
         # Import h5py imports mpi4py automatically.
         'h5py!=2.10.0',
         'toml>=0.10',
-        'dcorelib>=0.9.7',
+        # dcorelib 1.0.0 dropped `__version__` and reorganized the API that
+        # dcore._dispatcher imports, so it is not yet compatible. Pin to 0.9.x.
+        'dcorelib>=0.9.7,<1',
         'sympy',
         'cvxpy'
         ],
@@ -65,7 +67,6 @@ setup(
             "dcore = dcore.dcore:run",
             "dcore_check = dcore.dcore_check:run",
             "dcore_bse = dcore.dcore_bse:run",
-            "dcore_gk = dcore.dcore_gk:run",
             "dcore_mpicheck = dcore.dcore_mpicheck:run",
             "dcore_anacont = dcore.dcore_anacont:run",
             "dcore_spectrum = dcore.dcore_spectrum:run",


### PR DESCRIPTION
## Summary
Two packaging bugs that break a fresh install:

1. **`dcorelib` resolves to an incompatible 1.0.0.** `install_requires` only said `dcorelib>=0.9.7`, so a clean `pip install dcore` pulls dcorelib **1.0.0**, which dropped the `__version__` attribute and reorganized the `triqs_compat` API that `dcore._dispatcher` imports. The result is `ImportError: cannot import name '__version__' from 'dcorelib'` on `import dcore`. Pinned to `>=0.9.7,<1`.

2. **`dcore_gk` dangling console script.** `setup.py` registered `dcore_gk = dcore.dcore_gk:run`, but `src/dcore/dcore_gk.py` does not exist — it was removed in f6739e6 ("Removed sparse BSE codes"). The installed `dcore_gk` command was therefore broken. Removed the entry point.

## Verification
- `dcorelib>=0.9.7,<1` excludes 1.0.0 and allows 0.9.7 (checked with `packaging`).
- The remaining 7 console scripts all map to existing modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)