### PR TITLE
docs: list all impurity solvers in the option help text

### DIFF
--- a/src/dcore/program_options.py
+++ b/src/dcore/program_options.py
@@ -107,7 +107,7 @@ def create_parser(target_sections=None):
 
     # [impurity_solver]
     parser.add_option("impurity_solver", "name", str, 'null',
-                    "Name of impurity solver. Available options are null, TRIQS/cthyb, TRIQS/hubbard-I, ALPS/cthyb, ALPS/cthyb-seg, pomerol.")
+                    "Name of impurity solver. Available options are null, TRIQS/cthyb, TRIQS/hubbard-I, ALPS/cthyb, ALPS/cthyb-seg, pomerol, HPhi, JO/cthyb-seg, scipy/sparse.")
     parser.add_option("impurity_solver", "basis_rotation", str, 'None', "You can specify either 'Hloc', 'None', or the location of a file.")
     parser.allow_undefined_options("impurity_solver")
 


### PR DESCRIPTION
## Summary
`impurity_solver.name` help text listed only 6 of the registered solvers (`null, TRIQS/cthyb, TRIQS/hubbard-I, ALPS/cthyb, ALPS/cthyb-seg, pomerol`). Added the missing `HPhi`, `JO/cthyb-seg`, and `scipy/sparse` so the auto-generated option table matches `impurity_solvers.solver_classes`.

(An earlier revision also linked the spin_orbit/openmx/respack tutorial pages into the toctree, but those were intentionally excluded, so that change was dropped.)

## Notes (not in this PR — need maintainer/domain input)
- `doc/impuritysolvers/triqs_cthyb/cthyb.rst` still documents `perform_tail_fit`/`fit_*` under `[system]`, but `[system]` does not `allow_undefined_options`, so those keys now raise a parse error (the current control is the `no_tail_fit` boolean). A correct fix needs a rewrite of the tail-fit / Legendre sections against the current TRIQS/cthyb capabilities.
- HPhi and BSE (`dcore_bse` + `[bse]`) still have no reference/tutorial pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)