### PR TITLE
docs: warn that cthyb tail-fit/Legendre parameters are outdated

### DIFF
--- a/doc/impuritysolvers/triqs_cthyb/cthyb.rst
+++ b/doc/impuritysolvers/triqs_cthyb/cthyb.rst
@@ -127,6 +127,15 @@ we have to increase ``n_cycles`` or ``length_cycle`` or both of them
 High-frequency tail fit
 -----------------------
 
+.. warning::
+
+   The ``perform_tail_fit``, ``fit_max_moment``, ``fit_min_w`` and ``fit_max_w``
+   parameters used below are no longer available in the current version of
+   DCore, and the ``[system]`` block rejects them. The high-frequency treatment
+   is now controlled by the single boolean ``no_tail_fit`` in the ``[system]``
+   block: tail fitting is performed by default, and ``no_tail_fit = True``
+   disables it. This section is kept for reference and will be revised.
+
 The self energy computed with QMC becomes noisy at the high frequency region.
 This high-frequency tail can be fitted by using the following function:
 
@@ -228,6 +237,12 @@ For example, in the case of figure (a) above, we can find that ``iomega_max=4.0`
 
 Legendre filter
 ---------------
+
+.. warning::
+
+   The ``n_l`` parameter used below is no longer read from the ``[system]``
+   block in the current version of DCore, and the ``[system]`` block rejects it.
+   This section is kept for reference and will be revised.
 
 .. warning::
 


### PR DESCRIPTION
## Summary
The TRIQS/cthyb page's **High-frequency tail fit** and **Legendre filter** sections instruct users to set, in the `[system]` block:
- `perform_tail_fit`, `fit_max_moment`, `fit_min_w`, `fit_max_w`
- `n_l`

None of these are read anywhere in `src/dcore` (they were DCore's own parameters, removed at some point — confirmed by the page's own note "(not the solver parameter …)"). Because `[system]` does not `allow_undefined_options`, following the docs now raises a **parse error**. The current high-frequency control is the single boolean `no_tail_fit` in `[system]`.

This PR adds warning admonitions to both sections pointing users at `no_tail_fit`, so they don't blindly hit the parse error.

## Follow-up (needs maintainer/domain input)
A full rewrite of these two workflows against the current behavior (how `no_tail_fit` works in practice; whether Legendre is still reachable via TRIQS `[impurity_solver]` pass-through) is left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)