### PR TITLE
Speed up SumkDFT_opt upfold/downfold for contiguous projections

### DIFF
--- a/src/dcore/sumkdft_opt.py
+++ b/src/dcore/sumkdft_opt.py
@@ -212,7 +212,9 @@ class SumkDFT_opt(SumkDFT):
 
         idmat = [numpy.identity(
             self.n_orbitals[ik, ntoi[sp]], numpy.complex128) for sp in spn]
-        M = copy.deepcopy(idmat)
+        # M[ibl] is fully overwritten in the loop below, so no copy of idmat is
+        # needed (the previous copy.deepcopy was dead work done for every k).
+        M = [None] * len(idmat)
         for ibl in range(self.n_spin_blocks[self.SO]):
             ind = ntoi[spn[ibl]]
             n_orb = self.n_orbitals[ik, ind]
@@ -421,12 +423,15 @@ class SumkDFT_opt(SumkDFT):
         # gf_downfolded.from_L_G_R(
         #     projmat, gf_to_downfold, projmat.conjugate().transpose())
 
-        i_start = projindex[0]
-        i_end = projindex[0] + projindex.shape[0]
-        if numpy.allclose(projindex, list(range(i_start, i_end))):
-            gf_downfolded.data[:, :, :] += gf_to_downfold.data[:, i_start:i_end, i_start:i_end] * fac
-        else:
-            gf_downfolded.data[:, :, :] += gf_to_downfold.data[:, projindex, :][:, :, projindex] * fac
+        if projindex.size > 0:
+            i_start = projindex[0]
+            i_end = projindex[0] + projindex.shape[0]
+            # Exact integer comparison (allclose is tolerance-based and could
+            # misclassify large non-contiguous indices as contiguous).
+            if numpy.array_equal(projindex, numpy.arange(i_start, i_end)):
+                gf_downfolded.data[:, :, :] += gf_to_downfold.data[:, i_start:i_end, i_start:i_end] * fac
+            else:
+                gf_downfolded.data[:, :, :] += gf_to_downfold.data[:, projindex, :][:, :, projindex] * fac
 
         if overwrite_gf_inp:
             return None
@@ -460,8 +465,23 @@ class SumkDFT_opt(SumkDFT):
 
         # gf_upfolded.from_L_G_R(
         #     projmat.conjugate().transpose(), gf_to_upfold, projmat)
-        gf_upfolded.data[numpy.ix_(range(gf_to_upfold.data.shape[0]), projindex, projindex)] \
-            += gf_to_upfold.data * fac
+        if projindex.size > 0:
+            i_start = projindex[0]
+            i_end = projindex[0] + projindex.shape[0]
+            if numpy.array_equal(projindex, numpy.arange(i_start, i_end)):
+                # Contiguous projection: use a plain slice (a view) instead of
+                # the much slower advanced indexing, and avoid the temporary
+                # from `* fac` for the common fac = +-1.
+                target = gf_upfolded.data[:, i_start:i_end, i_start:i_end]
+                if fac == 1.0:
+                    target += gf_to_upfold.data
+                elif fac == -1.0:
+                    target -= gf_to_upfold.data
+                else:
+                    target += gf_to_upfold.data * fac
+            else:
+                gf_upfolded.data[numpy.ix_(range(gf_to_upfold.data.shape[0]), projindex, projindex)] \
+                    += gf_to_upfold.data * fac
 
         if overwrite_gf_inp:
             return None

--- a/tests/non-mpi/fold_index/test_fold_index.py
+++ b/tests/non-mpi/fold_index/test_fold_index.py
@@ -1,0 +1,107 @@
+#
+# DCore -- Integrated DMFT software for correlated electrons
+# Copyright (C) 2017 The University of Tokyo
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""
+Unit tests for the fancy-index up/down-fold of SumkDFT_opt.
+
+The contiguous-projection fast path (a plain slice) must produce exactly the
+same result as the advanced-index (numpy.ix_) formulation, for contiguous,
+non-contiguous and empty projection indices and for several `fac` values.
+"""
+import types
+
+import numpy as np
+import pytest
+
+# SumkDFT_opt pulls in the backend (dcorelib/TRIQS) via dcore._dispatcher.
+SumkDFT_opt = pytest.importorskip("dcore.sumkdft_opt").SumkDFT_opt
+
+
+class _FakeGf:
+    """Minimal stand-in for the backend Gf: only .data/.copy()/.zero()."""
+    def __init__(self, data):
+        self.data = data
+
+    def copy(self):
+        return _FakeGf(self.data.copy())
+
+    def zero(self):
+        self.data[...] = 0.0
+
+
+def _fake_self(projindex, n_orb):
+    s = types.SimpleNamespace()
+    s.SO = 0
+    s.spin_names_to_ind = {0: {"up": 0}}
+    s.n_orbitals = np.array([[n_orb]])              # [ik, isp]
+    s.corr_shells = [{"dim": len(projindex)}]
+    pi = np.zeros((1, 1, 1, len(projindex)), dtype=int)
+    pi[0, 0, 0, :] = projindex
+    s.proj_index = pi
+    return s
+
+
+def _rand(shape, rng):
+    return rng.standard_normal(shape) + 1j * rng.standard_normal(shape)
+
+
+@pytest.mark.parametrize("projindex", [[1, 2, 3], [1, 3, 4], []])
+@pytest.mark.parametrize("fac", [1.0, -1.0, 0.5])
+def test_upfold_index_matches_advanced_index(projindex, fac):
+    rng = np.random.RandomState(0)
+    niw, n_orb = 4, 6
+    projindex = np.array(projindex, dtype=int)
+    dim = projindex.size
+
+    inp0 = _rand((niw, n_orb, n_orb), rng)
+    src = _rand((niw, dim, dim), rng)
+
+    # reference: the original advanced-index update
+    ref = inp0.copy()
+    if dim > 0:
+        ref[np.ix_(range(niw), projindex, projindex)] += src * fac
+
+    got = _FakeGf(inp0.copy())
+    SumkDFT_opt.upfold_index(
+        _fake_self(projindex, n_orb), ik=0, ish=0, bname="up",
+        gf_to_upfold=_FakeGf(src), gf_inp=got, overwrite_gf_inp=True, fac=fac)
+
+    assert np.allclose(got.data, ref, atol=1e-13)
+
+
+@pytest.mark.parametrize("projindex", [[1, 2, 3], [1, 3, 4], []])
+@pytest.mark.parametrize("fac", [1.0, -1.0, 0.5])
+def test_downfold_index_matches_advanced_index(projindex, fac):
+    rng = np.random.RandomState(1)
+    niw, n_orb = 4, 6
+    projindex = np.array(projindex, dtype=int)
+    dim = projindex.size
+
+    src = _rand((niw, n_orb, n_orb), rng)
+    inp0 = _rand((niw, dim, dim), rng)
+
+    # reference: the original advanced-index update into a zeroed dim x dim block
+    ref = np.zeros((niw, dim, dim), dtype=np.complex128)
+    if dim > 0:
+        ref[:, :, :] += src[:, projindex, :][:, :, projindex] * fac
+
+    # overwrite_gf_inp=False returns a new (zeroed-then-filled) gf
+    out = SumkDFT_opt.downfold_index(
+        _fake_self(projindex, n_orb), ik=0, ish=0, bname="up",
+        gf_to_downfold=_FakeGf(src), gf_inp=_FakeGf(inp0.copy()), overwrite_gf_inp=False, fac=fac)
+
+    assert np.allclose(out.data, ref, atol=1e-13)


### PR DESCRIPTION
## Summary
Profiling the Gloc worker across orbital counts showed that, after the
O(n_orb^3) lattice-GF inversion, the largest cost at large `n_orb` was
`upfold_index()` — which always used advanced indexing (`numpy.ix_`).

- **`upfold_index`**: add a contiguous-projection fast path that writes through
  a plain slice (a view) instead of `numpy.ix_`, and avoid the temporary from
  `* fac` for the common `fac = +-1`.
- **`downfold_index`**: replace the tolerance-based `numpy.allclose` contiguity
  test with an exact integer `numpy.array_equal` (the old test could
  misclassify large non-contiguous indices), and guard `projindex.size > 0`.
- **`lattice_gf`**: drop the dead `M = copy.deepcopy(idmat)` — `M[ibl]` is fully
  overwritten for every block, so the per-k deep copy was wasted work.

## Measured effect
TRIQS-compat backend, single Gloc evaluation, nk=36, n_iw=1000:

| n_orb | total before → after | `upfold_index` before → after |
|------:|:--------------------:|:-----------------------------:|
| 8  | 6.32 → 5.75 s | 0.54 → 0.02 s |
| 16 | 11.17 → 9.16 s (-18%) | 2.25 → 0.12 s |
| 24 | 23.92 → 19.24 s (-20%) | 4.95 → 0.27 s |

The remaining dominant cost is the intrinsic O(n_orb^3) inversion.

## Verification
- wannier90 DMFT regression tests pass on numpy 1.26.4 and 2.5.0 (results
  unchanged vs reference).
- New unit tests `tests/non-mpi/fold_index/test_fold_index.py` (18 cases)
  compare the up/down-fold output against the advanced-index reference for
  contiguous, non-contiguous and empty projection indices and `fac = 1, -1, 0.5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)