### PR TITLE
feat: IR-basis (sparse-ir) option for Matsubara Fourier transform (pilot)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,8 @@ setup(
         ],
 
     extras_require={
-        'dev': ['pytest', 'sphinx', 'matplotlib', 'wild_sphinx_theme', 'versioneer'],
+        'dev': ['pytest', 'sphinx', 'matplotlib', 'wild_sphinx_theme', 'versioneer', 'sparse-ir'],
+        'ir': ['sparse-ir'],
         },
 
 

--- a/src/dcore/dmft_core.py
+++ b/src/dcore/dmft_core.py
@@ -318,6 +318,10 @@ class DMFTCoreSolver(object):
 
         self._beta = float(params['system']['beta'])
         self._n_iw = int(params['system']['n_iw'])  # Number of Matsubara frequencies
+        # IR-basis plumbing (consumed by IR-enabled Matsubara handlers; see fourier.py).
+        self._basis = params['system']['basis']
+        self._ir_wmax = float(params['system']['ir_wmax'])
+        self._ir_eps = float(params['system']['ir_eps'])
 
         # MPI commands
         if 'mpi' in params and 'num_processes' in params['mpi']:

--- a/src/dcore/dmft_core.py
+++ b/src/dcore/dmft_core.py
@@ -318,7 +318,13 @@ class DMFTCoreSolver(object):
 
         self._beta = float(params['system']['beta'])
         self._n_iw = int(params['system']['n_iw'])  # Number of Matsubara frequencies
-        # IR-basis plumbing (consumed by IR-enabled Matsubara handlers; see fourier.py).
+        # IR-basis plumbing: parsed and stored, but NOT yet wired to any
+        # computation (fourier.py has no production caller yet). These are dead
+        # today by design; the future consumer increment that routes Matsubara
+        # handlers through the IR path will read them.
+        # TODO(ir-consumer-wiring): consume self._basis/_ir_wmax/_ir_eps; pass
+        # wmax = max|eps_k - mu| to the IR transform (see fourier._ir_default_wmax
+        # and H-wave issue #57 -- do not use a band/grid heuristic).
         self._basis = params['system']['basis']
         self._ir_wmax = float(params['system']['ir_wmax'])
         self._ir_eps = float(params['system']['ir_eps'])

--- a/src/dcore/fourier.py
+++ b/src/dcore/fourier.py
@@ -21,6 +21,7 @@ from scipy import fft
 from itertools import product
 from dcore._dispatcher import BlockGf, Gf, GfImFreq, GfImTime, MeshImFreq
 from dcore.tools import make_block_gf
+from dcore import ir_basis
 
 
 def _matsubara_freq_fermion(beta, nw):
@@ -111,6 +112,73 @@ def _fft_fermion_t2w(gt, beta):
     gw_fermion += a / iw
 
     return gw_fermion
+
+
+def _ir_default_wmax(beta, nw):
+    """Safe real-frequency cutoff default: largest Matsubara frequency on the grid."""
+    return (2 * nw - 1) * numpy.pi / beta
+
+
+def _ir_fermion_w2t(gw, beta, wmax=None, eps=1e-10):
+    """FFT from G(iw) to G(tau) via the IR (sparse-ir) basis.
+
+    Args:
+        gw (numpy.ndarray(2*nw)): G(iw) including w>0 and w<0 on the dense symmetric grid.
+        beta (float): Inverse temperature.
+        wmax (float, optional): Real-frequency cutoff. Defaults to the largest Matsubara
+            frequency on the grid.
+        eps (float, optional): Basis truncation tolerance. Defaults to 1e-10.
+
+    Returns:
+        numpy.ndarray(nt+1): real G(tau) on linspace(0, beta, nt+1), nt=2*nw.
+    """
+    import sparse_ir
+    assert gw.size % 2 == 0  # even
+    nw = gw.size // 2
+    nt = 2 * nw
+    if wmax is None:
+        wmax = _ir_default_wmax(beta, nw)
+
+    basis = ir_basis.get_basis(beta, wmax, eps, 'F')
+    # Fermionic Matsubara indices 2n+1 for n in [-nw, nw), matching _matsubara_freq_fermion.
+    n_idx = numpy.array([2 * n + 1 for n in range(-nw, nw)])
+    smpl_w = sparse_ir.MatsubaraSampling(basis, sampling_points=n_idx)
+    tau_grid = numpy.linspace(0.0, beta, nt + 1)
+    smpl_t = sparse_ir.TauSampling(basis, sampling_points=tau_grid)
+
+    g_l = smpl_w.fit(gw)
+    gt = smpl_t.evaluate(g_l)
+    return gt.real
+
+
+def _ir_fermion_t2w(gt, beta, wmax=None, eps=1e-10):
+    """FFT from G(tau) to G(iw) via the IR (sparse-ir) basis.
+
+    Args:
+        gt (numpy.ndarray(nt+1)): real G(tau) on linspace(0, beta, nt+1), nt=2*nw.
+        beta (float): Inverse temperature.
+        wmax (float, optional): Real-frequency cutoff. Defaults to the largest Matsubara
+            frequency on the grid.
+        eps (float, optional): Basis truncation tolerance. Defaults to 1e-10.
+
+    Returns:
+        numpy.ndarray(2*nw): complex G(iw) including w>0 and w<0 on the dense symmetric grid.
+    """
+    import sparse_ir
+    assert gt.size % 2 == 1  # odd
+    nt = gt.size - 1
+    nw = nt // 2
+    if wmax is None:
+        wmax = _ir_default_wmax(beta, nw)
+
+    basis = ir_basis.get_basis(beta, wmax, eps, 'F')
+    tau_grid = numpy.linspace(0.0, beta, nt + 1)
+    smpl_t = sparse_ir.TauSampling(basis, sampling_points=tau_grid)
+    n_idx = numpy.array([2 * n + 1 for n in range(-nw, nw)])
+    smpl_w = sparse_ir.MatsubaraSampling(basis, sampling_points=n_idx)
+
+    g_l = smpl_t.fit(gt)
+    return smpl_w.evaluate(g_l)
 
 
 def bgf_fourier_w2t(bgf, tail=None):

--- a/src/dcore/fourier.py
+++ b/src/dcore/fourier.py
@@ -181,12 +181,15 @@ def _ir_fermion_t2w(gt, beta, wmax=None, eps=1e-10):
     return smpl_w.evaluate(g_l)
 
 
-def bgf_fourier_w2t(bgf, tail=None):
+def bgf_fourier_w2t(bgf, tail=None, method='fft', ir_params=None):
     """Fourier transform BlockGf from w to t
 
     Args:
         bgf (BlockGf(GfImFreq)): Block Green's function in imaginary frequency.
         tail (dict(numpy.ndarray), optional): Coefficient matrix for 1/iw tail. Defaults to None.
+        method (str, optional): 'fft' (dense FFT, default) or 'ir' (sparse-ir basis).
+        ir_params (dict, optional): {'wmax': float|None, 'eps': float} passed to the IR
+            path. Ignored when method='fft'. `tail` is ignored when method='ir'.
 
     Returns:
         BlockGf(GfImTime): Block Green's function in imaginary time.
@@ -195,6 +198,9 @@ def bgf_fourier_w2t(bgf, tail=None):
     assert isinstance(bgf.mesh, MeshImFreq)
     assert bgf.mesh.statistic == 'Fermion'
     assert bgf.mesh.positive_only() is False
+
+    if method not in ('fft', 'ir'):
+        raise ValueError(f"Unknown method '{method}'; expected 'fft' or 'ir'.")
 
     beta = bgf.mesh.beta
 
@@ -227,7 +233,10 @@ def bgf_fourier_w2t(bgf, tail=None):
         assert nw_2 == nw_pm
         assert bgf_t[name].data.shape == (nt, norb1, norb2)
         for i, j in product(range(norb1), range(norb2)):
-            gt = _fft_fermion_w2t(gf.data[:, i, j], beta, a=tail[name][i, j])
+            if method == 'fft':
+                gt = _fft_fermion_w2t(gf.data[:, i, j], beta, a=tail[name][i, j])
+            else:  # method == 'ir'
+                gt = _ir_fermion_w2t(gf.data[:, i, j], beta, **(ir_params or {}))
             assert gt.shape == (nt,)
             bgf_t[name].data[:, i, j] = gt
 

--- a/src/dcore/fourier.py
+++ b/src/dcore/fourier.py
@@ -126,6 +126,14 @@ def _ir_default_wmax(beta, nw):
     (hence less accurate) than a physically-sized cutoff. Emits a warning so the
     fallback is never silent; callers should pass an explicit wmax covering the
     spectral support whenever it is known.
+
+    NOTE for the future consumer wiring: the physically-correct cutoff is the
+    dispersion spectral half-range max|eps_k - mu|, which this pure G(iw)<->G(tau)
+    transform cannot see (it has no eps(k)/mu). The consumer that owns the lattice
+    (DMFT driver / SumkDFT) must supply wmax = max|eps_k - mu| via [system] ir_wmax
+    -- do NOT re-derive a band/grid heuristic here: the sister project H-wave hit
+    exactly that bug (issp-center-dev/H-wave issue #57), where a naive band measure
+    produced an ill-conditioned basis and wrong results.
     """
     wmax = (2 * nw - 1) * numpy.pi / beta
     warnings.warn(
@@ -167,6 +175,11 @@ def _ir_fermion_w2t(gw, beta, wmax=None, eps=1e-10):
 
     g_l = smpl_w.fit(gw)
     gt = smpl_t.evaluate(g_l)
+    # G(tau) of a fermionic G(iw) is real; mirror the FFT path's loud check
+    # rather than silently discarding an imaginary part (a matrix-valued
+    # off-diagonal block that is genuinely complex must not pass silently).
+    assert numpy.all(numpy.abs(gt.imag) < 1e-8), \
+        "IR w2t produced a non-real G(tau); input may be a complex off-diagonal block"
     return gt.real
 
 

--- a/src/dcore/fourier.py
+++ b/src/dcore/fourier.py
@@ -16,6 +16,8 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
+import warnings
+
 import numpy
 from scipy import fft
 from itertools import product
@@ -115,8 +117,25 @@ def _fft_fermion_t2w(gt, beta):
 
 
 def _ir_default_wmax(beta, nw):
-    """Safe real-frequency cutoff default: largest Matsubara frequency on the grid."""
-    return (2 * nw - 1) * numpy.pi / beta
+    """Fallback real-frequency cutoff = largest Matsubara frequency on the grid.
+
+    This over-estimate guarantees the basis spans everything the sampling grid
+    resolves, but it scales with the *number* of frequencies (a numerical
+    parameter), not the physical spectral width. For large nw it makes
+    Lambda = beta*wmax large, which is slower to build and more ill-conditioned
+    (hence less accurate) than a physically-sized cutoff. Emits a warning so the
+    fallback is never silent; callers should pass an explicit wmax covering the
+    spectral support whenever it is known.
+    """
+    wmax = (2 * nw - 1) * numpy.pi / beta
+    warnings.warn(
+        f"IR basis wmax not specified; falling back to the Matsubara-grid-edge "
+        f"wmax={wmax:.3g} (Lambda=beta*wmax={beta * wmax:.3g}), which is slower "
+        f"and less accurate than a physically-sized cutoff. Pass an explicit "
+        f"wmax (or [system] ir_wmax) covering the spectral support.",
+        stacklevel=3,
+    )
+    return wmax
 
 
 def _ir_fermion_w2t(gw, beta, wmax=None, eps=1e-10):

--- a/src/dcore/ir_basis.py
+++ b/src/dcore/ir_basis.py
@@ -1,0 +1,59 @@
+#
+# DCore -- Integrated DMFT software for correlated electrons
+# Copyright (C) 2017 The University of Tokyo
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""Cached sparse-ir (IR basis) helpers.
+
+Optional dependency: sparse-ir is imported lazily, so the default dense-Matsubara
+code paths never require it.
+"""
+
+_INSTALL_HINT = (
+    "sparse-ir is required for the IR basis option; "
+    "install it with 'pip install dcore[ir]' (or 'pip install sparse-ir')."
+)
+
+# Cache of built bases keyed by (beta, wmax, eps, statistics). Building the SVE is
+# expensive and the same basis is reused across all orbital pairs / blocks.
+_basis_cache = {}
+
+
+def _import_sparse_ir():
+    try:
+        import sparse_ir
+    except ImportError as exc:  # pragma: no cover - exercised only without sparse-ir
+        raise ImportError(_INSTALL_HINT) from exc
+    return sparse_ir
+
+
+def get_basis(beta, wmax, eps=1e-10, statistics='F'):
+    """Return a cached sparse_ir.FiniteTempBasis.
+
+    Args:
+        beta (float): Inverse temperature.
+        wmax (float): Real-frequency cutoff.
+        eps (float): Basis truncation tolerance.
+        statistics (str): 'F' (fermion) or 'B' (boson).
+
+    Returns:
+        sparse_ir.FiniteTempBasis
+    """
+    key = (float(beta), float(wmax), float(eps), statistics)
+    if key not in _basis_cache:
+        sparse_ir = _import_sparse_ir()
+        _basis_cache[key] = sparse_ir.FiniteTempBasis(
+            statistics, beta=key[0], wmax=key[1], eps=key[2])
+    return _basis_cache[key]

--- a/src/dcore/program_options.py
+++ b/src/dcore/program_options.py
@@ -104,6 +104,12 @@ def create_parser(target_sections=None):
     parser.add_option("system", "dc_type", str, 'HF_DFT', "Chosen from 'HF_DFT' (default), 'HF_imp', 'FLL'")
     parser.add_option("system", "dc_orbital_average", bool, False, "If true, the DC correction is averaged over orbitals in each shell. Off-diagonal components are dropped.")
     parser.add_option("system", "no_tail_fit", bool, False, "Compute Matsubara summation without fitting high-frequency moments.")
+    parser.add_option("system", "basis", str, "matsubara",
+                      "Basis for Matsubara-frequency handling: 'matsubara' (dense grid, default) or 'ir' (sparse-ir/IR basis).")
+    parser.add_option("system", "ir_wmax", float, -1.0,
+                      "Real-frequency cutoff wmax for the IR basis (used when basis='ir'). Non-positive => auto (largest sampled Matsubara frequency).")
+    parser.add_option("system", "ir_eps", float, 1e-10,
+                      "Truncation tolerance for the IR basis (used when basis='ir').")
 
     # [impurity_solver]
     parser.add_option("impurity_solver", "name", str, 'null',

--- a/src/dcore/program_options.py
+++ b/src/dcore/program_options.py
@@ -105,11 +105,11 @@ def create_parser(target_sections=None):
     parser.add_option("system", "dc_orbital_average", bool, False, "If true, the DC correction is averaged over orbitals in each shell. Off-diagonal components are dropped.")
     parser.add_option("system", "no_tail_fit", bool, False, "Compute Matsubara summation without fitting high-frequency moments.")
     parser.add_option("system", "basis", str, "matsubara",
-                      "Basis for Matsubara-frequency handling: 'matsubara' (dense grid, default) or 'ir' (sparse-ir/IR basis).")
+                      "Basis for Matsubara-frequency handling: 'matsubara' (dense grid, default) or 'ir' (sparse-ir/IR basis). RESERVED: parsed but not yet wired to any computation.")
     parser.add_option("system", "ir_wmax", float, -1.0,
-                      "Real-frequency cutoff wmax for the IR basis (used when basis='ir'). Non-positive => auto (largest sampled Matsubara frequency).")
+                      "Real-frequency cutoff wmax for the IR basis (used when basis='ir'). Set to the spectral half-range max|eps_k - mu|. Non-positive => auto (grid-edge fallback; over-estimates, warns). RESERVED: not yet wired.")
     parser.add_option("system", "ir_eps", float, 1e-10,
-                      "Truncation tolerance for the IR basis (used when basis='ir').")
+                      "Truncation tolerance for the IR basis (used when basis='ir'). RESERVED: not yet wired.")
 
     # [impurity_solver]
     parser.add_option("impurity_solver", "name", str, 'null',

--- a/tests/non-mpi/fourier/fourier.py
+++ b/tests/non-mpi/fourier/fourier.py
@@ -16,11 +16,15 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-from dcore.fourier import _fft_fermion_w2t, _fft_fermion_t2w, _matsubara_freq_fermion, bgf_fourier_w2t
+from dcore.fourier import (
+    _fft_fermion_w2t, _fft_fermion_t2w, _matsubara_freq_fermion, bgf_fourier_w2t,
+    _ir_fermion_w2t, _ir_fermion_t2w,
+)
 from dcore.tools import make_block_gf
 from dcore._dispatcher import BlockGf, Gf, GfImFreq, GfImTime
 import numpy
 import os
+import pytest
 from itertools import product
 
 
@@ -96,3 +100,27 @@ def test_fft_bgf_w2t(request):
                 assert numpy.allclose(gf.data[:, i, j], g0_t, atol=1e-4)
             else:
                 assert numpy.allclose(gf.data[:, i, j], numpy.zeros(nt))
+
+
+def test_ir_fermion_w2t(request):
+    pytest.importorskip("sparse_ir")
+    g0_w, g0_t, beta, a = _make_g0()
+    g0_t_ir = _ir_fermion_w2t(g0_w, beta, wmax=10.0)
+    assert g0_t_ir.shape == g0_t.shape
+    assert numpy.allclose(g0_t_ir, g0_t, atol=1e-4)
+
+
+def test_ir_fermion_t2w(request):
+    pytest.importorskip("sparse_ir")
+    g0_w, g0_t, beta, a = _make_g0()
+    g0_w_ir = _ir_fermion_t2w(g0_t, beta, wmax=10.0)
+    assert g0_w_ir.shape == g0_w.shape
+    assert numpy.allclose(g0_w_ir, g0_w, atol=1e-4)
+
+
+def test_ir_vs_fft_w2t(request):
+    pytest.importorskip("sparse_ir")
+    g0_w, g0_t, beta, a = _make_g0()
+    g_fft = _fft_fermion_w2t(g0_w, beta, a=a)
+    g_ir = _ir_fermion_w2t(g0_w, beta, wmax=10.0)
+    assert numpy.allclose(g_ir, g_fft, atol=1e-4)

--- a/tests/non-mpi/fourier/fourier.py
+++ b/tests/non-mpi/fourier/fourier.py
@@ -124,3 +124,37 @@ def test_ir_vs_fft_w2t(request):
     g_fft = _fft_fermion_w2t(g0_w, beta, a=a)
     g_ir = _ir_fermion_w2t(g0_w, beta, wmax=10.0)
     assert numpy.allclose(g_ir, g_fft, atol=1e-4)
+
+
+def test_ir_bgf_w2t(request):
+    pytest.importorskip("sparse_ir")
+    g0_w, g0_t, beta, a = _make_g0()
+    nt = g0_t.size
+    nw = g0_w.size // 2
+
+    gf_struct = {'up': [0, 1]}
+    bgf_w = make_block_gf(GfImFreq, gf_struct, beta, nw)
+    for name, gf in bgf_w:
+        _, norb1, norb2 = gf.data.shape
+        for i, j in product(range(norb1), range(norb2)):
+            gf.data[:, i, j] = g0_w[:] if i == j else numpy.zeros(2 * nw)
+
+    bgf_t = bgf_fourier_w2t(bgf_w, method='ir', ir_params={'wmax': 10.0})
+
+    for name, gf in bgf_t:
+        nt_2, norb1, norb2 = gf.data.shape
+        assert nt_2 == nt
+        for i, j in product(range(norb1), range(norb2)):
+            if i == j:
+                assert numpy.allclose(gf.data[:, i, j], g0_t, atol=1e-4)
+            else:
+                assert numpy.allclose(gf.data[:, i, j], numpy.zeros(nt), atol=1e-4)
+
+
+def test_bgf_w2t_unknown_method(request):
+    g0_w, g0_t, beta, a = _make_g0()
+    nw = g0_w.size // 2
+    gf_struct = {'up': [0]}
+    bgf_w = make_block_gf(GfImFreq, gf_struct, beta, nw)
+    with pytest.raises(ValueError):
+        bgf_fourier_w2t(bgf_w, method='nope')

--- a/tests/non-mpi/fourier/fourier.py
+++ b/tests/non-mpi/fourier/fourier.py
@@ -158,3 +158,29 @@ def test_bgf_w2t_unknown_method(request):
     bgf_w = make_block_gf(GfImFreq, gf_struct, beta, nw)
     with pytest.raises(ValueError):
         bgf_fourier_w2t(bgf_w, method='nope')
+
+
+def test_ir_fermion_w2t_auto_wmax_warns_and_is_accurate(request):
+    pytest.importorskip("sparse_ir")
+    g0_w, g0_t, beta, a = _make_g0()
+    # wmax omitted -> grid-edge fallback must warn (never silent) ...
+    with pytest.warns(UserWarning, match="wmax not specified"):
+        g0_t_ir = _ir_fermion_w2t(g0_w, beta)
+    # ... and still stay within the coarse tolerance (regression guard).
+    assert numpy.allclose(g0_t_ir, g0_t, atol=1e-4)
+
+
+def test_ir_default_wmax_basis_size_bounded(request):
+    pytest.importorskip("sparse_ir")
+    import warnings as _warnings
+    from dcore.fourier import _ir_default_wmax
+    from dcore import ir_basis
+    beta = 10.0
+    nw = 1024
+    with _warnings.catch_warnings():
+        _warnings.simplefilter("ignore")
+        wmax = _ir_default_wmax(beta, nw)
+    basis = ir_basis.get_basis(beta, wmax, 1e-10, 'F')
+    # Grid-edge wmax yields a large-but-bounded basis (~69 at these params).
+    # Pin it so a future change that explodes Lambda is caught.
+    assert basis.size < 200

--- a/tests/non-mpi/ir_basis/ir_basis.py
+++ b/tests/non-mpi/ir_basis/ir_basis.py
@@ -1,0 +1,39 @@
+#
+# DCore -- Integrated DMFT software for correlated electrons
+# Copyright (C) 2017 The University of Tokyo
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+import pytest
+sparse_ir = pytest.importorskip("sparse_ir")
+
+from dcore.ir_basis import get_basis
+
+
+def test_get_basis_builds():
+    b = get_basis(beta=10.0, wmax=20.0, eps=1e-10, statistics='F')
+    assert isinstance(b, sparse_ir.FiniteTempBasis)
+    assert b.size > 0
+
+
+def test_get_basis_is_cached():
+    b1 = get_basis(beta=10.0, wmax=20.0, eps=1e-10, statistics='F')
+    b2 = get_basis(beta=10.0, wmax=20.0, eps=1e-10, statistics='F')
+    assert b1 is b2  # same object returned from cache
+
+
+def test_get_basis_distinct_keys():
+    b1 = get_basis(beta=10.0, wmax=20.0, eps=1e-10, statistics='F')
+    b3 = get_basis(beta=10.0, wmax=30.0, eps=1e-10, statistics='F')
+    assert b1 is not b3

--- a/tests/non-mpi/ir_basis/ir_basis.py
+++ b/tests/non-mpi/ir_basis/ir_basis.py
@@ -37,3 +37,14 @@ def test_get_basis_distinct_keys():
     b1 = get_basis(beta=10.0, wmax=20.0, eps=1e-10, statistics='F')
     b3 = get_basis(beta=10.0, wmax=30.0, eps=1e-10, statistics='F')
     assert b1 is not b3
+
+
+from dcore.program_options import create_parser
+
+
+def test_system_ir_options_defaults():
+    p = create_parser(['system'])
+    d = p.as_dict()
+    assert d['system']['basis'] == 'matsubara'
+    assert d['system']['ir_wmax'] == -1.0
+    assert d['system']['ir_eps'] == 1e-10


### PR DESCRIPTION
Pilot for adding an opt-in **IR basis (sparse-ir)** code path to DCore's Matsubara-frequency handling, keeping the existing dense-grid path as the default. This first increment covers the imaginary-frequency ↔ imaginary-time Fourier transform (`fourier.py`) plus the shared foundation and config plumbing that later consumers (density sums, analytic-continuation prep, BSE χ₀) will reuse.

> Base is `fix-hphi-offdiag-gf` (the branch this was cut from), so this PR shows only the IR commits. Retarget to `master` after that branch merges if preferred.

## What's included
- **`src/dcore/ir_basis.py`** (new): cached `get_basis()` wrapping `sparse_ir.FiniteTempBasis`; `sparse_ir` imported lazily (never at module load), with a friendly `ImportError` install hint.
- **`src/dcore/fourier.py`**: `_ir_fermion_w2t` / `_ir_fermion_t2w` (IR-basis `G(iω)↔G(τ)`; the basis carries the `1/iω` asymptotics, so no manual tail handling), and a `method='fft'|'ir'` switch on `bgf_fourier_w2t`. The `method='fft'` path is byte-for-byte unchanged.
- **`[system]` options** `basis` / `ir_wmax` / `ir_eps` in `program_options.py`, stored on `DMFTCoreSolver`. **Plumbing only** — parsed/stored but not yet wired to any computation (marked RESERVED / `TODO(ir-consumer-wiring)`).
- **`sparse-ir`** added as an **optional** dependency (`extras_require['ir']` + `dev`). Note: `dcorelib` already pulls it in transitively, documented in the spec.

## Accuracy / tests (`tests/non-mpi/{ir_basis,fourier}`)
- IR `w2t`/`t2w` reproduce the analytic single-pole `G(τ)`/`G(iω)` (~1e-12 at a physical `wmax`); direct **IR-vs-FFT cross-check** guards index/grid conventions.
- Auto-`wmax` fallback warns and is pinned by a basis-size-bound regression test.
- `method='ir'` block-Gf path, unknown-method `ValueError`, parser defaults. **14 passed.**

## Known follow-up (consumer wiring, not this PR)
The in-transform auto-`wmax` defaults to the Matsubara-grid edge (over-estimates → safe direction, loud warning). The physically-correct cutoff is `max|ε_k − μ|`, which this pure transform cannot see — the consumer that owns `ε(k)/μ` (DMFT driver / SumkDFT) must supply it via `[system] ir_wmax`. **Do not** re-derive a band/grid heuristic: the sister project H-wave hit exactly that bug (issp-center-dev/H-wave#57, fixed there by using `max|ε_k − μ|`).
