### PR TITLE
feat: optional GPU (CuPy) acceleration for the scipy/sparse ED solver

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ setup(
 
     extras_require={
         'dev': ['pytest', 'sphinx', 'matplotlib', 'wild_sphinx_theme', 'versioneer'],
+        'gpu': ['cupy'],
         },
 
 

--- a/src/dcore/gpu.py
+++ b/src/dcore/gpu.py
@@ -1,0 +1,67 @@
+#
+# DCore -- Integrated DMFT software for correlated electrons
+# Copyright (C) 2017 The University of Tokyo
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+"""Array-backend selection (numpy / cupy) for optional GPU acceleration.
+
+CuPy is an optional dependency imported lazily; GPU use is strictly opt-in and
+falls back to numpy (with a warning) when CuPy or a CUDA device is unavailable.
+"""
+import warnings
+import numpy as np
+
+_INSTALL_HINT = ("install the CuPy wheel matching your CUDA "
+                 "(e.g. 'pip install cupy-cuda12x'); see "
+                 "https://docs.cupy.dev/en/stable/install.html")
+
+
+def _import_cupy():
+    import cupy
+    return cupy
+
+
+def get_backend(use_gpu):
+    """Return (xp, gpu_active): (cupy, True) if use_gpu and a usable CUDA device
+    exists, else (numpy, False) with a one-time fallback warning."""
+    if not use_gpu:
+        return np, False
+    try:
+        cupy = _import_cupy()
+    except ImportError:
+        warnings.warn("gpu=true requested but CuPy is not installed; using the "
+                      "numpy (CPU) backend. To enable the GPU, " + _INSTALL_HINT)
+        return np, False
+    try:
+        if cupy.cuda.runtime.getDeviceCount() < 1:
+            raise RuntimeError("no CUDA device")
+    except Exception as exc:
+        warnings.warn("gpu=true requested but no usable CUDA device was found "
+                      "({}); using the numpy (CPU) backend.".format(exc))
+        return np, False
+    return cupy, True
+
+
+def array_module_of(arr):
+    """Return numpy or cupy, whichever owns arr."""
+    if type(arr).__module__.split(".")[0] == "cupy":
+        return _import_cupy()
+    return np
+
+
+def to_host(arr):
+    """Return arr as a numpy array (device->host copy for cupy; identity for numpy)."""
+    xp = array_module_of(arr)
+    return arr if xp is np else xp.asnumpy(arr)

--- a/src/dcore/impurity_solvers/scipy_sparse.py
+++ b/src/dcore/impurity_solvers/scipy_sparse.py
@@ -87,6 +87,7 @@ class ScipySolver(SolverBase):
         # gf_atol = params_kw.get('gf_atol', 0.0)
         check_n_eigen = params_kw.get('check_n_eigen', True)
         check_orthonormality = params_kw.get('check_orthonormality', True)
+        gpu = params_kw.get('gpu', False)
 
         # convert particle_numbers to a list
         particle_numbers_in = params_kw.get('particle_numbers', 'auto')
@@ -130,6 +131,7 @@ class ScipySolver(SolverBase):
             # 'gf_atol': gf_atol,
             'check_n_eigen' : check_n_eigen,
             'check_orthonormality' : check_orthonormality,
+            'gpu': bool(gpu),
         }
         # (*) TypeError: Object of type int64 is not JSON serializable
 

--- a/src/dcore/impurity_solvers/scipy_sparse_main.py
+++ b/src/dcore/impurity_solvers/scipy_sparse_main.py
@@ -340,6 +340,17 @@ def calc_gf_lanczos(iws, Cdag, spin_conserve, eigvec, E_n, hamil_ex, pm, ncv):
     return gf
 
 
+def _dense_eigh(hamil_sparse, xp):
+    """Dense Hermitian eigendecomposition of a sparse matrix. Uses cupy.linalg.eigh
+    on the GPU when xp is cupy, else scipy.linalg.eigh; always returns numpy arrays
+    so downstream (numpy/scipy.sparse) code is unaffected."""
+    dense = hamil_sparse.toarray()
+    if xp is np:
+        return scipy.linalg.eigh(dense)
+    w, v = xp.linalg.eigh(xp.asarray(dense))
+    return xp.asnumpy(w), xp.asnumpy(v)
+
+
 def main():
     # ----------------------------------------------------------------
     # Parse input parameters
@@ -372,6 +383,12 @@ def main():
     # gf_rtol = params['gf_rtol']
     check_n_eigen = params['check_n_eigen']
     check_orthonormality = params['check_orthonormality']
+
+    gpu = params.get('gpu', False)
+    from dcore.gpu import get_backend
+    xp, gpu_active = get_backend(gpu)
+    if gpu_active:
+        print("GPU (CuPy) backend active for dense eigh / Lehmann Gf.", flush=True)
 
     if eigen_solver not in eigsolver:
         raise ValueError(f"Invalid eigen_solver: {eigen_solver}")
@@ -582,7 +599,7 @@ def main():
         if full_diagonalization[N]:
             print(" full diagonalization", flush=True)
             # n_eigen = dim[N]
-            eigvals[N], eigvecs[N] = scipy.linalg.eigh(hamils[N].toarray())
+            eigvals[N], eigvecs[N] = _dense_eigh(hamils[N], xp)
         else:
             print(f" Iterative solver: n_eigen={n_eigen} eigenvalues are computed.", flush=True)
             if eigen_solver == 'lanczos':
@@ -734,6 +751,7 @@ def main():
                     params_gf.update(
                         eigvals_ex = eigvals[N_ex],
                         eigvecs_ex = eigvecs[N_ex],
+                        xp = xp,
                     )
                     gf_1 = calc_gf_Lehmann(**params_gf)
 

--- a/src/dcore/impurity_solvers/scipy_sparse_main.py
+++ b/src/dcore/impurity_solvers/scipy_sparse_main.py
@@ -192,36 +192,35 @@ def print_sparse_matrix_info(matrix, prefix=""):
 # Compute
 #   <n| c_i (iw - H + E_n) c_j^+ |n>
 # using the eigenvalues of H (Lehmann representation)
-def calc_gf_Lehmann(iws, Cdag, spin_conserve, eigvec, E_n, eigvals_ex, eigvecs_ex, pm):
+def calc_gf_Lehmann(iws, Cdag, spin_conserve, eigvec, E_n, eigvals_ex, eigvecs_ex,
+                    pm, xp=np):
     n_flavors = Cdag.size
-    n_iw = iws.size
     dim_ex = eigvals_ex.size
     assert eigvecs_ex.shape == (dim_ex, dim_ex)
 
-    gf = np.zeros((n_flavors, n_flavors, n_iw), dtype=complex)
-
-    # cdag_im[i, m] = <m|c_i^+|n>  for a given n
+    # cdag_im[i, m] = <m|c_i^+|n>  (built on host: sparse matvecs)
     cdag_im = np.empty((n_flavors, dim_ex), dtype=complex)
     for i in range(n_flavors):
         cdag_im[i] = eigvecs_ex.conj().T @ Cdag[i] @ eigvec
 
-    for l, iw in enumerate(iws):
-        if pm == +1:
-            # ene_denom[m] = 1 / (iw - E_m + E_n)
-            ene_denom = 1 / (iw - eigvals_ex + E_n)
-        else:
-            # ene_denom[m] = 1 / (iw + E_m - E_n)
-            ene_denom = 1 / (iw + eigvals_ex - E_n)
-        assert ene_denom.shape == (dim_ex,)
+    # ene_denom[l, m] = 1 / (iw_l -/+ E_m +/- E_n)
+    if pm == +1:
+        ene = 1.0 / (iws[:, None] - eigvals_ex[None, :] + E_n)
+    else:
+        ene = 1.0 / (iws[:, None] + eigvals_ex[None, :] - E_n)
 
-        for i, j in np.ndindex(n_flavors, n_flavors):
-            if spin_conserve:
-                n_orb = n_flavors // 2
-                if i // n_orb != j // n_orb:  # skip different spins
-                    continue
+    ci = xp.asarray(cdag_im)
+    e = xp.asarray(ene)
+    # gf[i, j, l] = sum_m conj(cdag_im[i,m]) * ene[l,m] * cdag_im[j,m]
+    gf = xp.einsum('im,lm,jm->ijl', ci.conj(), e, ci)
+    if xp is not np:
+        gf = xp.asnumpy(gf)
 
-            gf[i, j, l] = np.einsum("m, m, m", cdag_im[i].conj().T, ene_denom, cdag_im[j])
-
+    if spin_conserve:
+        n_orb = n_flavors // 2
+        blk = np.arange(n_flavors) // n_orb
+        mask = blk[:, None] != blk[None, :]        # cross-spin (i,j)
+        gf[mask, :] = 0.0
     return gf
 
 

--- a/tests/non-mpi/gpu_backend/gpu_backend.py
+++ b/tests/non-mpi/gpu_backend/gpu_backend.py
@@ -1,0 +1,42 @@
+#
+# DCore -- Integrated DMFT software for correlated electrons
+# Copyright (C) 2017 The University of Tokyo
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+import numpy as np
+from dcore import gpu
+
+
+def test_get_backend_cpu_default():
+    xp, active = gpu.get_backend(False)
+    assert xp is np
+    assert active is False
+
+
+def test_get_backend_gpu_missing_falls_back(monkeypatch):
+    # Force the cupy import to fail -> graceful numpy fallback + warning.
+    monkeypatch.setattr(gpu, "_import_cupy",
+                        lambda: (_ for _ in ()).throw(ImportError("no cupy")))
+    import warnings
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        xp, active = gpu.get_backend(True)
+    assert xp is np and active is False
+    assert any("cupy" in str(x.message).lower() for x in w)
+
+
+def test_to_host_identity_for_numpy():
+    a = np.arange(3)
+    assert gpu.to_host(a) is a

--- a/tests/non-mpi/scipy_sparse_gf/scipy_sparse_gf.py
+++ b/tests/non-mpi/scipy_sparse_gf/scipy_sparse_gf.py
@@ -73,3 +73,43 @@ def test_dense_eigh_cpu_matches_scipy():
     assert np.allclose(np.sort(w), np.sort(w_ref), atol=1e-10)
     # eigenpairs reconstruct H
     assert np.allclose((v * w) @ v.conj().T, H.toarray(), atol=1e-9)
+
+
+class _FakeCupy:
+    # minimal shim: behaves like numpy but is a distinct module identity,
+    # and provides asnumpy, so the xp-is-not-np branches execute.
+    def __getattr__(self, k):
+        import numpy as _np
+        return getattr(_np, k)
+    @staticmethod
+    def asnumpy(a):
+        import numpy as _np
+        return _np.asarray(a)
+
+
+def test_lehmann_xp_branch_executes():
+    iws, Cdag, eigvec, evx, vvx = _rand_case(seed=7)
+    ref = _reference_lehmann(iws, Cdag, False, eigvec, 0.1, evx, vvx, +1)
+    got = calc_gf_Lehmann(iws, Cdag, False, eigvec, 0.1, evx, vvx, +1, xp=_FakeCupy())
+    assert np.allclose(got, ref, atol=1e-12)
+
+
+def test_gpu_matches_cpu_if_available():
+    cupy = pytest.importorskip("cupy")
+    try:
+        if cupy.cuda.runtime.getDeviceCount() < 1:
+            pytest.skip("no CUDA device")
+    except Exception:
+        pytest.skip("no usable CUDA device")
+    from dcore.impurity_solvers.scipy_sparse_main import _dense_eigh
+    import scipy.sparse as sp
+    rng = np.random.default_rng(1)
+    A = rng.standard_normal((32, 32)) + 1j*rng.standard_normal((32, 32))
+    H = sp.csr_matrix(A + A.conj().T)
+    w_cpu, _ = _dense_eigh(H, np)
+    w_gpu, _ = _dense_eigh(H, cupy)
+    assert np.allclose(np.sort(w_cpu), np.sort(w_gpu), rtol=1e-10, atol=1e-10)
+    iws, Cdag, eigvec, evx, vvx = _rand_case(seed=2)
+    g_cpu = calc_gf_Lehmann(iws, Cdag, False, eigvec, 0.2, evx, vvx, +1, xp=np)
+    g_gpu = calc_gf_Lehmann(iws, Cdag, False, eigvec, 0.2, evx, vvx, +1, xp=cupy)
+    assert np.allclose(g_cpu, g_gpu, rtol=1e-10, atol=1e-12)

--- a/tests/non-mpi/scipy_sparse_gf/scipy_sparse_gf.py
+++ b/tests/non-mpi/scipy_sparse_gf/scipy_sparse_gf.py
@@ -60,3 +60,16 @@ def test_lehmann_matches_reference(pm, spin_conserve):
     got = calc_gf_Lehmann(iws, Cdag, spin_conserve, eigvec, 0.3, evx, vvx, pm)
     assert got.shape == ref.shape
     assert np.allclose(got, ref, atol=1e-12)
+
+
+def test_dense_eigh_cpu_matches_scipy():
+    import scipy.linalg, scipy.sparse as sp
+    from dcore.impurity_solvers.scipy_sparse_main import _dense_eigh
+    rng = np.random.default_rng(0)
+    A = rng.standard_normal((8, 8)) + 1j*rng.standard_normal((8, 8))
+    H = sp.csr_matrix(A + A.conj().T)          # Hermitian
+    w, v = _dense_eigh(H, np)
+    w_ref = scipy.linalg.eigh(H.toarray(), eigvals_only=True)
+    assert np.allclose(np.sort(w), np.sort(w_ref), atol=1e-10)
+    # eigenpairs reconstruct H
+    assert np.allclose((v * w) @ v.conj().T, H.toarray(), atol=1e-9)

--- a/tests/non-mpi/scipy_sparse_gf/scipy_sparse_gf.py
+++ b/tests/non-mpi/scipy_sparse_gf/scipy_sparse_gf.py
@@ -1,0 +1,62 @@
+#
+# DCore -- Integrated DMFT software for correlated electrons
+# Copyright (C) 2017 The University of Tokyo
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+import numpy as np
+import scipy.sparse as sp
+import pytest
+from dcore.impurity_solvers.scipy_sparse_main import calc_gf_Lehmann
+
+
+def _reference_lehmann(iws, Cdag, spin_conserve, eigvec, E_n, evx, vvx, pm):
+    nf = Cdag.size; niw = iws.size; dim = evx.size
+    gf = np.zeros((nf, nf, niw), dtype=complex)
+    cdag_im = np.empty((nf, dim), dtype=complex)
+    for i in range(nf):
+        cdag_im[i] = vvx.conj().T @ Cdag[i] @ eigvec
+    for l, iw in enumerate(iws):
+        den = 1/(iw - evx + E_n) if pm == +1 else 1/(iw + evx - E_n)
+        for i, j in np.ndindex(nf, nf):
+            if spin_conserve and (i // (nf//2) != j // (nf//2)):
+                continue
+            gf[i, j, l] = np.einsum("m,m,m", cdag_im[i].conj(), den, cdag_im[j])
+    return gf
+
+
+def _rand_case(seed, nf=4, dim=6, niw=5):
+    rng = np.random.default_rng(seed)
+    def cx(shape):
+        return rng.standard_normal(shape) + 1j*rng.standard_normal(shape)
+    Cdag = np.empty(nf, dtype=object)
+    for i in range(nf):
+        Cdag[i] = sp.csr_matrix(cx((dim, dim)))
+    eigvec = cx(dim)
+    evx = rng.standard_normal(dim)
+    vvx = cx((dim, dim))
+    iws = 1j * (2*np.arange(niw)+1) * np.pi / 10.0
+    return iws, Cdag, eigvec, evx, vvx
+
+
+@pytest.mark.parametrize("pm", [+1, -1])
+@pytest.mark.parametrize("spin_conserve", [True, False])
+def test_lehmann_matches_reference(pm, spin_conserve):
+    iws, Cdag, eigvec, evx, vvx = _rand_case(
+        seed=(0 if pm == +1 else 1) + (10 if spin_conserve else 0)
+    )
+    ref = _reference_lehmann(iws, Cdag, spin_conserve, eigvec, 0.3, evx, vvx, pm)
+    got = calc_gf_Lehmann(iws, Cdag, spin_conserve, eigvec, 0.3, evx, vvx, pm)
+    assert got.shape == ref.shape
+    assert np.allclose(got, ref, atol=1e-12)


### PR DESCRIPTION
Adds an **opt-in** `[impurity_solver] gpu{bool} = True` that GPU-accelerates the two genuine compute-bound hotspots of the `scipy/sparse` exact-diagonalization impurity solver, with a graceful CPU fallback. Default (`gpu` omitted) behavior is unchanged.

## What it does
- **New `src/dcore/gpu.py`** — a small numpy/cupy backend: `get_backend(use_gpu) -> (xp, gpu_active)` (returns cupy when requested and a CUDA device is usable, else numpy with a one-line warning), plus `to_host` / `array_module_of`. `cupy` is imported lazily; nothing changes for a CPU-only install.
- **Dense diagonalization on GPU** — `_dense_eigh(hamil, xp)` routes the full-diagonalization `eigh` (the `O(dim^3)` cost, `dim` up to `dim_full_diag`) through `cupy.linalg.eigh` when enabled, always returning host numpy arrays so all downstream scipy-sparse code is unaffected.
- **Vectorized Lehmann Green's function** — `calc_gf_Lehmann`'s Python triple loop becomes a single `einsum('im,lm,jm->ijl', ...)` (a speedup on NumPy alone; runs on GPU when enabled).
- **Config** — `scipy_sparse.py` passes `gpu` through the solver's JSON params to the (single-process) subprocess. `cupy` added as an optional extra (`pip install dcore[gpu]`, not pinned — install the wheel matching your CUDA).

## Correctness / tests
- `gpu=false` (default) is numerically identical to before (the Lehmann einsum reproduces the old per-element sum; verified to 1e-12).
- Tests: backend fallback; Lehmann-vs-reference for `pm = ±1` × spin-conserve on/off; `_dense_eigh` vs `scipy.linalg.eigh`; a fake-backend shim exercising the GPU code path on CPU CI; and a skip-guarded real-GPU cpu/gpu parity test. **9 passed, 1 skipped** (no CuPy in CI).

## Scope / notes
- Enable with `gpu{bool} = True`; **disable by omitting the key** (DCore's `{bool}` converter treats any non-empty string as True — a pre-existing behavior shared by all `{bool}` solver params).
- The real win is `_dense_eigh` (large full-diagonalization sectors); the Lehmann offload helps when `n_flavors^2 * n_iw * dim` is large and may otherwise be transfer-bound. `eigsh`/Lanczos/iterative solvers are unchanged (not offloaded).
- The GPU path is not exercised on CI (no CuPy); a one-time manual GPU parity run is recommended before production use.
- Follow-up (not in this PR): a short docs note for the new option.