### PR TITLE
ci: fix deploy_docs race on concurrent gh-pages pushes

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -10,6 +10,15 @@ on:
       - '!gh-pages'
     tags: '*'
 
+# Serialize ALL deploy runs, regardless of trigger ref, because every job
+# mutates the one shared gh-pages branch. A single constant group prevents
+# both same-ref and cross-ref (e.g. master + develop) races on gh-pages;
+# per-ref grouping would leave cross-ref deploys racing. cancel-in-progress
+# is false so a running deploy is never interrupted mid-push.
+concurrency:
+  group: deploy-docs
+  cancel-in-progress: false
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -71,10 +80,12 @@ jobs:
           git config --local user.name "${GIT_USER}"
           git config --local user.email "${GIT_EMAIL}"
           git remote set-url origin git@github.com:${GITHUB_REPOSITORY}.git
-          git pull
           git add ${TARGET_NAME}
           if git commit -m "Deploy docs to ${TARGET_NAME} by GitHub Actions triggered by ${GITHUB_SHA}"
           then
+            # Commit first, then rebase on any concurrent remote updates so the
+            # working tree is clean when we pull (avoids the overwrite abort).
+            git pull --rebase origin gh-pages
             git push origin gh-pages
           else
             echo "Nothing to deploy"


### PR DESCRIPTION
## 背景

`develop` に複数のPRが短時間に連続マージされる、あるいは `master` と `develop` など別refへのpushが近接すると、`deploy` (docs公開) ワークフローが並行実行され、以下のエラーで失敗していました:

\`\`\`
error: Your local changes to the following files would be overwritten by merge:
	develop/.doctrees/environment.pickle
	develop/impuritysolvers/triqs_cthyb/cthyb.html
	...
Please commit your changes or stash them before you merge.
Aborting
\`\`\`

### 原因

`deploy_docs.yml` の Push ステップは以下の順序で処理します:

1. ビルド済みドキュメントを `gh-pages/<target>/` に `cp`(tracked ファイルが変更状態になる)
2. `git pull`  ← **ここで失敗**
3. `git add` → `git commit` → `git push`

並行する別ジョブが先に push すると、後発ジョブの `git pull` が、まだ commit していないコピー済みファイルとリモート更新の衝突を検出して中断します。コードのバグではなく同時実行のレースです。

## 修正

1. **`concurrency` グループで全 deploy を直列化** — どのジョブも唯一の共有リソースである `gh-pages` ブランチを更新するため、group キーは trigger ref ではなく定数 `deploy-docs` とし、同一ref・別ref(master + develop 等)双方のレースを排除。`cancel-in-progress: false` で実行中の deploy を push 途中に中断しない。
2. **`git pull` を `git add`/`git commit` の後ろに移動**し `git pull --rebase origin gh-pages` に変更。コピー済みファイルを先に commit してワーキングツリーをクリーンにし、万一の並行更新の上に自分の commit を rebase で乗せる(多層防御)。

## レビュー

AIコードレビューを2周実施。1周目で「group を `github.ref` で分けると別refのdeployが依然レースする」指摘があり、定数グループへ変更して解消。2周目で新規指摘なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)